### PR TITLE
feat: show section overviews on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,135 +121,135 @@
     <!-- PROGRAMS_TREE_START (auto-generated) -->
 <details><summary>Vol 01 Foundations <span class='desc'>— Groundwork in thinking, communication, math, science, and creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 <ul>
-<li><details><summary>Chapter 01 <span class='desc'>— The Beginning of Inquiry</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 01 <span class='desc'>— Introduce the idea of a liberal education and define education in your own words.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html'>Section 01</a> <span class='desc'>— What is a Liberal Education?</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html'>Section 01</a> <span class='desc'>— Introduce the idea of a liberal education and define education in your own words.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.html'>Section 02</a> <span class='desc'>— The Power of Story</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-03.html'>Section 03</a> <span class='desc'>— Mathematics as a Language</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-04.html'>Section 04</a> <span class='desc'>— Observing the Natural World</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.html'>Section 05</a> <span class='desc'>— Mapping the Mind</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 02 <span class='desc'>— Chapter 2</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 02 <span class='desc'>— Strengthen core reasoning skills and learn how logical arguments are built.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.html'>Section 01</a> <span class='desc'>— Logic & Reasoning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.html'>Section 01</a> <span class='desc'>— Strengthen core reasoning skills and learn how logical arguments are built.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.html'>Section 02</a> <span class='desc'>— Voice & Style</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-03.html'>Section 03</a> <span class='desc'>— Patterns & Sequences</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-04.html'>Section 04</a> <span class='desc'>— Motion & Measurement</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.html'>Section 05</a> <span class='desc'>— Creative Constraints</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 03 <span class='desc'>— Chapter 3</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 03 <span class='desc'>— Consider what it means to live an examined life and question assumptions.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.html'>Section 01</a> <span class='desc'>— The Examined Life</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.html'>Section 01</a> <span class='desc'>— Consider what it means to live an examined life and question assumptions.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.html'>Section 02</a> <span class='desc'>— Argument & Persuasion</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-03.html'>Section 03</a> <span class='desc'>— Ratios & Proportions</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-04.html'>Section 04</a> <span class='desc'>— Forces & Balance</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.html'>Section 05</a> <span class='desc'>— Play as Learning</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 04 <span class='desc'>— Chapter 4</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 04 <span class='desc'>— Explore how perspective shapes truth and recognize bias in observation.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.html'>Section 01</a> <span class='desc'>— Truth & Perspectives</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.html'>Section 01</a> <span class='desc'>— Explore how perspective shapes truth and recognize bias in observation.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.html'>Section 02</a> <span class='desc'>— Structure & Flow</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-03.html'>Section 03</a> <span class='desc'>— Infinity & Limits</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-04.html'>Section 04</a> <span class='desc'>— Energy & Work</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.html'>Section 05</a> <span class='desc'>— Storytelling Through Images</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 05 <span class='desc'>— Chapter 5</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 05 <span class='desc'>— Learn classical rhetoric techniques to persuade and connect with audiences.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.html'>Section 01</a> <span class='desc'>— Rhetoric & Persuasion</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.html'>Section 01</a> <span class='desc'>— Learn classical rhetoric techniques to persuade and connect with audiences.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.html'>Section 02</a> <span class='desc'>— Audience Awareness</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-03.html'>Section 03</a> <span class='desc'>— Probability & Uncertainty</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-04.html'>Section 04</a> <span class='desc'>— Sound & Vibration</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.html'>Section 05</a> <span class='desc'>— Improvisation & Surprise</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 06 <span class='desc'>— Chapter 6</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 06 <span class='desc'>— Use writing as a tool for clear thinking and precise communication.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.html'>Section 01</a> <span class='desc'>— Writing as Clear Thinking</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.html'>Section 01</a> <span class='desc'>— Use writing as a tool for clear thinking and precise communication.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.html'>Section 02</a> <span class='desc'>— Writing as Clear Thinking</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-03.html'>Section 03</a> <span class='desc'>— Statistics as Storytelling</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-04.html'>Section 04</a> <span class='desc'>— Light & Perception</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.html'>Section 05</a> <span class='desc'>— Sound & Rhythm</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 07 <span class='desc'>— Chapter 7</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 07 <span class='desc'>— See mathematics as a universal language and translate ideas into symbols.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.html'>Section 01</a> <span class='desc'>— Mathematics as Language</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.html'>Section 01</a> <span class='desc'>— See mathematics as a universal language and translate ideas into symbols.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.html'>Section 02</a> <span class='desc'>— Writing from Sources</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-03.html'>Section 03</a> <span class='desc'>— Geometry in Nature</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-04.html'>Section 04</a> <span class='desc'>— Gravity & Orbits</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.html'>Section 05</a> <span class='desc'>— Design with Found Objects</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 08 <span class='desc'>— Chapter 8</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 08 <span class='desc'>— Survey ethical frameworks to navigate moral dilemmas with nuance.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.html'>Section 01</a> <span class='desc'>— Ethics & Moral Reasoning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.html'>Section 01</a> <span class='desc'>— Survey ethical frameworks to navigate moral dilemmas with nuance.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.html'>Section 02</a> <span class='desc'>— Revision as Discovery</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-03.html'>Section 03</a> <span class='desc'>— Symmetry & Beauty</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-04.html'>Section 04</a> <span class='desc'>— Electricity & Circuits</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.html'>Section 05</a> <span class='desc'>— Collaboration & Exchange</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 09 <span class='desc'>— Chapter 9</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 09 <span class='desc'>— Apply the scientific method to investigate questions about the world.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.html'>Section 01</a> <span class='desc'>— Science & Inquiry</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.html'>Section 01</a> <span class='desc'>— Apply the scientific method to investigate questions about the world.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.html'>Section 02</a> <span class='desc'>— Storytelling in Oral Traditions</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-03.html'>Section 03</a> <span class='desc'>— Numbers in Music</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-04.html'>Section 04</a> <span class='desc'>— Waves in Nature</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.html'>Section 05</a> <span class='desc'>— Creative Spaces</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 10 <span class='desc'>— Chapter 10</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 10 <span class='desc'>— Unlock creativity through imagination and experimentation.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.html'>Section 01</a> <span class='desc'>— Imagination & Creativity</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.html'>Section 01</a> <span class='desc'>— Unlock creativity through imagination and experimentation.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.html'>Section 02</a> <span class='desc'>— Writing for Media</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-03.html'>Section 03</a> <span class='desc'>— Chaos & Complexity</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-04.html'>Section 04</a> <span class='desc'>— Heat & Thermodynamics</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.html'>Section 05</a> <span class='desc'>— Patterns in Chaos</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 11 <span class='desc'>— Chapter 11</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 11 <span class='desc'>— Understand how memory works and practice techniques to retain learning.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.html'>Section 01</a> <span class='desc'>— Memory & Learning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.html'>Section 01</a> <span class='desc'>— Understand how memory works and practice techniques to retain learning.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.html'>Section 02</a> <span class='desc'>— Writing & Identity</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-03.html'>Section 03</a> <span class='desc'>— Math in Technology</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-04.html'>Section 04</a> <span class='desc'>— Momentum & Collisions</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.html'>Section 05</a> <span class='desc'>— Art & Technology</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 12 <span class='desc'>— Chapter 12</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 12 <span class='desc'>— Examine cultures and worldviews to broaden global understanding.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.html'>Section 01</a> <span class='desc'>— Culture & Worldviews</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.html'>Section 01</a> <span class='desc'>— Examine cultures and worldviews to broaden global understanding.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.html'>Section 02</a> <span class='desc'>— Writing in Community</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-03.html'>Section 03</a> <span class='desc'>— Visualizing Data</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-04.html'>Section 04</a> <span class='desc'>— Scale of the Universe</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.html'>Section 05</a> <span class='desc'>— Creativity Across Cultures</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 13 <span class='desc'>— Chapter 13</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 13 <span class='desc'>— Trace tools of thought from ancient to digital to extend human intellect.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.html'>Section 01</a> <span class='desc'>— Technology & Tools of Thought</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.html'>Section 01</a> <span class='desc'>— Trace tools of thought from ancient to digital to extend human intellect.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.html'>Section 02</a> <span class='desc'>— Writing & Technology</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-03.html'>Section 03</a> <span class='desc'>— The Philosophy of Numbers</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-04.html'>Section 04</a> <span class='desc'>— Chaos & Randomness</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.html'>Section 05</a> <span class='desc'>— Creative Risks</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 14 <span class='desc'>— Chapter 14</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 14 <span class='desc'>— Debate how knowledge is formed and justified across disciplines.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.html'>Section 01</a> <span class='desc'>— Philosophy of Knowledge</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.html'>Section 01</a> <span class='desc'>— Debate how knowledge is formed and justified across disciplines.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.html'>Section 02</a> <span class='desc'>— Writing as Reflection</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-03.html'>Section 03</a> <span class='desc'>— Math as Creativity</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-04.html'>Section 04</a> <span class='desc'>— Science & Society</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.html'>Section 05</a> <span class='desc'>— Creative Flow</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 15 <span class='desc'>— Chapter 15</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>🔗</a></summary>
+<li><details><summary>Chapter 15 <span class='desc'>— Synthesize your learning into a personal philosophy of learning and life.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.html'>Section 01</a> <span class='desc'>— My Philosophy of Learning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.html'>Section 01</a> <span class='desc'>— Synthesize your learning into a personal philosophy of learning and life.</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.html'>Section 02</a> <span class='desc'>— My Manifesto of Voice</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-03.html'>Section 03</a> <span class='desc'>— My Math Philosophy</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-04.html'>Section 04</a> <span class='desc'>— My Philosophy of Science</span></li>

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter01-section01
+overview: "Introduce the idea of a liberal education and define education in your own words."
+Overview: Introduce the idea of a liberal education and define education in your own words.
 title: Section 01 — What is a Liberal Education? (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 1

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter02-section01
+overview: "Strengthen core reasoning skills and learn how logical arguments are built."
+Overview: Strengthen core reasoning skills and learn how logical arguments are built.
 title: Section 01 — Logic & Reasoning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 2

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter03-section01
+overview: "Consider what it means to live an examined life and question assumptions."
+Overview: Consider what it means to live an examined life and question assumptions.
 title: Section 01 — The Examined Life (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 3

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter04-section01
+overview: "Explore how perspective shapes truth and recognize bias in observation."
+Overview: Explore how perspective shapes truth and recognize bias in observation.
 title: Section 01 — Truth & Perspectives (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 4

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter05-section01
+overview: "Learn classical rhetoric techniques to persuade and connect with audiences."
+Overview: Learn classical rhetoric techniques to persuade and connect with audiences.
 title: Section 01 — Rhetoric & Persuasion (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 5

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter06-section01
+overview: "Use writing as a tool for clear thinking and precise communication."
+Overview: Use writing as a tool for clear thinking and precise communication.
 title: Section 01 — Writing as Clear Thinking (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 6

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter07-section01
+overview: "See mathematics as a universal language and translate ideas into symbols."
+Overview: See mathematics as a universal language and translate ideas into symbols.
 title: Section 01 — Mathematics as Language (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 7

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter08-section01
+overview: "Survey ethical frameworks to navigate moral dilemmas with nuance."
+Overview: Survey ethical frameworks to navigate moral dilemmas with nuance.
 title: Section 01 — Ethics & Moral Reasoning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 8

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter09-section01
+overview: "Apply the scientific method to investigate questions about the world."
+Overview: Apply the scientific method to investigate questions about the world.
 title: Section 01 — Science & Inquiry (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 9

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter10-section01
+overview: "Unlock creativity through imagination and experimentation."
+Overview: Unlock creativity through imagination and experimentation.
 title: Section 01 — Imagination & Creativity (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 10

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter11-section01
+overview: "Understand how memory works and practice techniques to retain learning."
+Overview: Understand how memory works and practice techniques to retain learning.
 title: Section 01 — Memory & Learning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 11

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter12-section01
+overview: "Examine cultures and worldviews to broaden global understanding."
+Overview: Examine cultures and worldviews to broaden global understanding.
 title: Section 01 — Culture & Worldviews (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 12

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter13-section01
+overview: "Trace tools of thought from ancient to digital to extend human intellect."
+Overview: Trace tools of thought from ancient to digital to extend human intellect.
 title: Section 01 — Technology & Tools of Thought (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 13

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter14-section01
+overview: "Debate how knowledge is formed and justified across disciplines."
+Overview: Debate how knowledge is formed and justified across disciplines.
 title: Section 01 — Philosophy of Knowledge (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 14

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.md
@@ -1,5 +1,7 @@
 ---
 id: vol01-chapter15-section01
+overview: "Synthesize your learning into a personal philosophy of learning and life."
+Overview: Synthesize your learning into a personal philosophy of learning and life.
 title: Section 01 — My Philosophy of Learning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 15


### PR DESCRIPTION
## Summary
- add per-chapter section overviews and show them on the site index
- read first-section overviews to describe each chapter
- clean up program tree generator and swap link icons

## Testing
- `python3 scripts/generate_programs_tree.py`
- `python3 scripts/validate.py` *(fails: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68c0cfbfe980832eacd9fd41093021d9