### PR TITLE
Add section overviews and show descriptions in program index

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,158 +119,158 @@
     </div>
 
     <!-- PROGRAMS_TREE_START (auto-generated) -->
-<details><summary>Vol 01 Foundations <span class='desc'>— Groundwork in thinking, communication, math, science, and creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 01 Foundations <span class='desc'>— Groundwork in thinking, communication, math, science, and creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 <ul>
-<li><details><summary>Chapter 01 <span class='desc'>— The Beginning of Inquiry</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 01 <span class='desc'>— The Beginning of Inquiry</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html'>Section 01</a> <span class='desc'>— What is a Liberal Education? (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.html'>Section 02</a> <span class='desc'>— The Power of Story (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-03.html'>Section 03</a> <span class='desc'>— Mathematics as a Language (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-04.html'>Section 04</a> <span class='desc'>— Observing the Natural World (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.html'>Section 05</a> <span class='desc'>— Mapping the Mind (The Beginning of Inquiry)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html'>Section 01</a> <span class='desc'>— What is a Liberal Education?</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.html'>Section 02</a> <span class='desc'>— The Power of Story</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-03.html'>Section 03</a> <span class='desc'>— Mathematics as a Language</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-04.html'>Section 04</a> <span class='desc'>— Observing the Natural World</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.html'>Section 05</a> <span class='desc'>— Mapping the Mind</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 02 <span class='desc'>— Chapter 2</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 02 <span class='desc'>— Chapter 2</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.html'>Section 01</a> <span class='desc'>— Logic & Reasoning (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.html'>Section 02</a> <span class='desc'>— Voice & Style (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-03.html'>Section 03</a> <span class='desc'>— Patterns & Sequences (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-04.html'>Section 04</a> <span class='desc'>— Motion & Measurement (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.html'>Section 05</a> <span class='desc'>— Creative Constraints (Chapter 2)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.html'>Section 01</a> <span class='desc'>— Logic & Reasoning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.html'>Section 02</a> <span class='desc'>— Voice & Style</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-03.html'>Section 03</a> <span class='desc'>— Patterns & Sequences</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-04.html'>Section 04</a> <span class='desc'>— Motion & Measurement</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.html'>Section 05</a> <span class='desc'>— Creative Constraints</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 03 <span class='desc'>— Chapter 3</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 03 <span class='desc'>— Chapter 3</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.html'>Section 01</a> <span class='desc'>— The Examined Life (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.html'>Section 02</a> <span class='desc'>— Argument & Persuasion (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-03.html'>Section 03</a> <span class='desc'>— Ratios & Proportions (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-04.html'>Section 04</a> <span class='desc'>— Forces & Balance (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.html'>Section 05</a> <span class='desc'>— Play as Learning (Chapter 3)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.html'>Section 01</a> <span class='desc'>— The Examined Life</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.html'>Section 02</a> <span class='desc'>— Argument & Persuasion</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-03.html'>Section 03</a> <span class='desc'>— Ratios & Proportions</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-04.html'>Section 04</a> <span class='desc'>— Forces & Balance</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.html'>Section 05</a> <span class='desc'>— Play as Learning</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 04 <span class='desc'>— Chapter 4</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 04 <span class='desc'>— Chapter 4</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.html'>Section 01</a> <span class='desc'>— Truth & Perspectives (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.html'>Section 02</a> <span class='desc'>— Structure & Flow (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-03.html'>Section 03</a> <span class='desc'>— Infinity & Limits (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-04.html'>Section 04</a> <span class='desc'>— Energy & Work (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.html'>Section 05</a> <span class='desc'>— Storytelling Through Images (Chapter 4)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.html'>Section 01</a> <span class='desc'>— Truth & Perspectives</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.html'>Section 02</a> <span class='desc'>— Structure & Flow</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-03.html'>Section 03</a> <span class='desc'>— Infinity & Limits</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-04.html'>Section 04</a> <span class='desc'>— Energy & Work</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.html'>Section 05</a> <span class='desc'>— Storytelling Through Images</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 05 <span class='desc'>— Chapter 5</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 05 <span class='desc'>— Chapter 5</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.html'>Section 01</a> <span class='desc'>— Rhetoric & Persuasion (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.html'>Section 02</a> <span class='desc'>— Audience Awareness (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-03.html'>Section 03</a> <span class='desc'>— Probability & Uncertainty (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-04.html'>Section 04</a> <span class='desc'>— Sound & Vibration (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.html'>Section 05</a> <span class='desc'>— Improvisation & Surprise (Chapter 5)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.html'>Section 01</a> <span class='desc'>— Rhetoric & Persuasion</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.html'>Section 02</a> <span class='desc'>— Audience Awareness</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-03.html'>Section 03</a> <span class='desc'>— Probability & Uncertainty</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-04.html'>Section 04</a> <span class='desc'>— Sound & Vibration</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.html'>Section 05</a> <span class='desc'>— Improvisation & Surprise</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 06 <span class='desc'>— Chapter 6</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 06 <span class='desc'>— Chapter 6</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.html'>Section 01</a> <span class='desc'>— Writing as Clear Thinking (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.html'>Section 02</a> <span class='desc'>— Writing as Clear Thinking (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-03.html'>Section 03</a> <span class='desc'>— Statistics as Storytelling (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-04.html'>Section 04</a> <span class='desc'>— Light & Perception (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.html'>Section 05</a> <span class='desc'>— Sound & Rhythm (Chapter 6)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.html'>Section 01</a> <span class='desc'>— Writing as Clear Thinking</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.html'>Section 02</a> <span class='desc'>— Writing as Clear Thinking</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-03.html'>Section 03</a> <span class='desc'>— Statistics as Storytelling</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-04.html'>Section 04</a> <span class='desc'>— Light & Perception</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.html'>Section 05</a> <span class='desc'>— Sound & Rhythm</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 07 <span class='desc'>— Chapter 7</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 07 <span class='desc'>— Chapter 7</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.html'>Section 01</a> <span class='desc'>— Mathematics as Language (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.html'>Section 02</a> <span class='desc'>— Writing from Sources (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-03.html'>Section 03</a> <span class='desc'>— Geometry in Nature (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-04.html'>Section 04</a> <span class='desc'>— Gravity & Orbits (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.html'>Section 05</a> <span class='desc'>— Design with Found Objects (Chapter 7)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.html'>Section 01</a> <span class='desc'>— Mathematics as Language</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.html'>Section 02</a> <span class='desc'>— Writing from Sources</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-03.html'>Section 03</a> <span class='desc'>— Geometry in Nature</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-04.html'>Section 04</a> <span class='desc'>— Gravity & Orbits</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.html'>Section 05</a> <span class='desc'>— Design with Found Objects</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 08 <span class='desc'>— Chapter 8</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 08 <span class='desc'>— Chapter 8</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.html'>Section 01</a> <span class='desc'>— Ethics & Moral Reasoning (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.html'>Section 02</a> <span class='desc'>— Revision as Discovery (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-03.html'>Section 03</a> <span class='desc'>— Symmetry & Beauty (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-04.html'>Section 04</a> <span class='desc'>— Electricity & Circuits (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.html'>Section 05</a> <span class='desc'>— Collaboration & Exchange (Chapter 8)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.html'>Section 01</a> <span class='desc'>— Ethics & Moral Reasoning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.html'>Section 02</a> <span class='desc'>— Revision as Discovery</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-03.html'>Section 03</a> <span class='desc'>— Symmetry & Beauty</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-04.html'>Section 04</a> <span class='desc'>— Electricity & Circuits</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.html'>Section 05</a> <span class='desc'>— Collaboration & Exchange</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 09 <span class='desc'>— Chapter 9</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 09 <span class='desc'>— Chapter 9</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.html'>Section 01</a> <span class='desc'>— Science & Inquiry (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.html'>Section 02</a> <span class='desc'>— Storytelling in Oral Traditions (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-03.html'>Section 03</a> <span class='desc'>— Numbers in Music (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-04.html'>Section 04</a> <span class='desc'>— Waves in Nature (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.html'>Section 05</a> <span class='desc'>— Creative Spaces (Chapter 9)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.html'>Section 01</a> <span class='desc'>— Science & Inquiry</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.html'>Section 02</a> <span class='desc'>— Storytelling in Oral Traditions</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-03.html'>Section 03</a> <span class='desc'>— Numbers in Music</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-04.html'>Section 04</a> <span class='desc'>— Waves in Nature</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.html'>Section 05</a> <span class='desc'>— Creative Spaces</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 10 <span class='desc'>— Chapter 10</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 10 <span class='desc'>— Chapter 10</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.html'>Section 01</a> <span class='desc'>— Imagination & Creativity (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.html'>Section 02</a> <span class='desc'>— Writing for Media (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-03.html'>Section 03</a> <span class='desc'>— Chaos & Complexity (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-04.html'>Section 04</a> <span class='desc'>— Heat & Thermodynamics (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.html'>Section 05</a> <span class='desc'>— Patterns in Chaos (Chapter 10)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.html'>Section 01</a> <span class='desc'>— Imagination & Creativity</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.html'>Section 02</a> <span class='desc'>— Writing for Media</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-03.html'>Section 03</a> <span class='desc'>— Chaos & Complexity</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-04.html'>Section 04</a> <span class='desc'>— Heat & Thermodynamics</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.html'>Section 05</a> <span class='desc'>— Patterns in Chaos</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 11 <span class='desc'>— Chapter 11</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 11 <span class='desc'>— Chapter 11</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.html'>Section 01</a> <span class='desc'>— Memory & Learning (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.html'>Section 02</a> <span class='desc'>— Writing & Identity (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-03.html'>Section 03</a> <span class='desc'>— Math in Technology (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-04.html'>Section 04</a> <span class='desc'>— Momentum & Collisions (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.html'>Section 05</a> <span class='desc'>— Art & Technology (Chapter 11)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.html'>Section 01</a> <span class='desc'>— Memory & Learning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.html'>Section 02</a> <span class='desc'>— Writing & Identity</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-03.html'>Section 03</a> <span class='desc'>— Math in Technology</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-04.html'>Section 04</a> <span class='desc'>— Momentum & Collisions</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.html'>Section 05</a> <span class='desc'>— Art & Technology</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 12 <span class='desc'>— Chapter 12</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 12 <span class='desc'>— Chapter 12</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.html'>Section 01</a> <span class='desc'>— Culture & Worldviews (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.html'>Section 02</a> <span class='desc'>— Writing in Community (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-03.html'>Section 03</a> <span class='desc'>— Visualizing Data (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-04.html'>Section 04</a> <span class='desc'>— Scale of the Universe (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.html'>Section 05</a> <span class='desc'>— Creativity Across Cultures (Chapter 12)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.html'>Section 01</a> <span class='desc'>— Culture & Worldviews</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.html'>Section 02</a> <span class='desc'>— Writing in Community</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-03.html'>Section 03</a> <span class='desc'>— Visualizing Data</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-04.html'>Section 04</a> <span class='desc'>— Scale of the Universe</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.html'>Section 05</a> <span class='desc'>— Creativity Across Cultures</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 13 <span class='desc'>— Chapter 13</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 13 <span class='desc'>— Chapter 13</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.html'>Section 01</a> <span class='desc'>— Technology & Tools of Thought (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.html'>Section 02</a> <span class='desc'>— Writing & Technology (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-03.html'>Section 03</a> <span class='desc'>— The Philosophy of Numbers (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-04.html'>Section 04</a> <span class='desc'>— Chaos & Randomness (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.html'>Section 05</a> <span class='desc'>— Creative Risks (Chapter 13)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.html'>Section 01</a> <span class='desc'>— Technology & Tools of Thought</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.html'>Section 02</a> <span class='desc'>— Writing & Technology</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-03.html'>Section 03</a> <span class='desc'>— The Philosophy of Numbers</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-04.html'>Section 04</a> <span class='desc'>— Chaos & Randomness</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.html'>Section 05</a> <span class='desc'>— Creative Risks</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 14 <span class='desc'>— Chapter 14</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 14 <span class='desc'>— Chapter 14</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.html'>Section 01</a> <span class='desc'>— Philosophy of Knowledge (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.html'>Section 02</a> <span class='desc'>— Writing as Reflection (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-03.html'>Section 03</a> <span class='desc'>— Math as Creativity (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-04.html'>Section 04</a> <span class='desc'>— Science & Society (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.html'>Section 05</a> <span class='desc'>— Creative Flow (Chapter 14)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.html'>Section 01</a> <span class='desc'>— Philosophy of Knowledge</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.html'>Section 02</a> <span class='desc'>— Writing as Reflection</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-03.html'>Section 03</a> <span class='desc'>— Math as Creativity</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-04.html'>Section 04</a> <span class='desc'>— Science & Society</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.html'>Section 05</a> <span class='desc'>— Creative Flow</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 15 <span class='desc'>— Chapter 15</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 15 <span class='desc'>— Chapter 15</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.html'>Section 01</a> <span class='desc'>— My Philosophy of Learning (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.html'>Section 02</a> <span class='desc'>— My Manifesto of Voice (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-03.html'>Section 03</a> <span class='desc'>— My Math Philosophy (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-04.html'>Section 04</a> <span class='desc'>— My Philosophy of Science (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-05.html'>Section 05</a> <span class='desc'>— Creative Manifesto (Chapter 15)</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.html'>Section 01</a> <span class='desc'>— My Philosophy of Learning</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.html'>Section 02</a> <span class='desc'>— My Manifesto of Voice</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-03.html'>Section 03</a> <span class='desc'>— My Math Philosophy</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-04.html'>Section 04</a> <span class='desc'>— My Philosophy of Science</span></li>
+<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-05.html'>Section 05</a> <span class='desc'>— Creative Manifesto</span></li>
 </ul>
 </details></li>
 </ul>
 </details>
-<details><summary>Vol 02 Ethics And Reasoning <span class='desc'>— Explore moral philosophy and sharpen logical reasoning.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 02 Ethics And Reasoning <span class='desc'>— Explore moral philosophy and sharpen logical reasoning.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 03 Communication Rhetoric <span class='desc'>— Develop effective communication and persuasive skills.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 03 Communication Rhetoric <span class='desc'>— Develop effective communication and persuasive skills.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 04 Science Systems <span class='desc'>— Investigate scientific principles and complex systems.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 04 Science Systems <span class='desc'>— Investigate scientific principles and complex systems.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 05 Design Creativity <span class='desc'>— Practice design thinking to unlock creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 05 Design Creativity <span class='desc'>— Practice design thinking to unlock creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 06 Economy History <span class='desc'>— Trace economic ideas through historical contexts.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 06 Economy History <span class='desc'>— Trace economic ideas through historical contexts.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 07 Technology Society <span class='desc'>— Examine technology's role in shaping society.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 07 Technology Society <span class='desc'>— Examine technology's role in shaping society.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 08 Leadership Citizenship <span class='desc'>— Build leadership skills and civic responsibility.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 08 Leadership Citizenship <span class='desc'>— Build leadership skills and civic responsibility.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
     <!-- PROGRAMS_TREE_END -->
 </main>

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter01-section01
-title: "Section 01 — What is a Liberal Education? (LBS 101)"
+title: Section 01 — What is a Liberal Education? (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 1
 section: 1
 course: LBS 101 – The Mental Gym
+description: What is a Liberal Education?
 ---
+
 
 # Section 01 — What is a Liberal Education?
 Course: LBS 101 – The Mental Gym
+
+## Overview
+What is a Liberal Education?
+
 
 ## Learning Session
 Explore These Materials:
@@ -29,4 +35,3 @@ Write one quote from today’s materials that you want to keep:
 
 ## Hard Problem (Optional)
 List 10 required courses for your “ideal university.” What does this reveal about your aims?
-

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter01-section02
-title: "Section 02 — The Power of Story (LBS 105)"
+title: Section 02 — The Power of Story (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 1
 section: 2
 course: LBS 105 – Writing & Communication I
+description: The Power of Story
 ---
+
 
 # Section 02 — The Power of Story
 Course: LBS 105 – Writing & Communication I: Rhetoric and Storytelling
+
+## Overview
+The Power of Story
+
 
 ## Learning Session
 Explore These Materials:
@@ -30,4 +36,3 @@ Write one quote from today’s materials that you want to keep:
 
 ## Hard Problem (Optional)
 Rewrite the same story twice: as a political speech and as a children’s bedtime story. What changes and why?
-

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-03.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter01-section03
-title: "Section 03 — Mathematics as a Language (LBS 110)"
+title: Section 03 — Mathematics as a Language (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 1
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Mathematics as a Language
 ---
+
 
 # Section 03 — Mathematics as a Language
 Course: LBS 110 – Mathematics for Modern Thinkers
+
+## Overview
+Mathematics as a Language
+
 
 ## Learning Session
 Explore These Materials:
@@ -28,4 +34,3 @@ Explore These Materials:
 
 ### Optional Hard Problem
 Fibonacci spiral or natural ratios collection; does math explain beauty or describe it?
-

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-04.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter01-section04
-title: "Section 04 — Observing the Natural World (LBS 120)"
+title: Section 04 — Observing the Natural World (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 1
 section: 4
 course: LBS 120 – Physics with Lab
+description: Observing the Natural World
 ---
+
 
 # Section 04 — Observing the Natural World
 Course: LBS 120 – Physics with Lab
+
+## Overview
+Observing the Natural World
+
 
 ## Learning Session
 Explore These Materials:
@@ -24,4 +30,3 @@ Explore These Materials:
 1. Simple Motion Experiment — Drop two objects; record and sketch results; note surprises.  
 2. Shadow Tracking — Track a shadow every 15 minutes for 2 hours; what does it suggest about Earth’s motion?  
 3. Reflection — Seeing vs assuming; what changed when I slowed down?
-

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter01-section05
-title: "Section 05 — Mapping the Mind (LAB 101)"
+title: Section 05 — Mapping the Mind (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 1
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Mapping the Mind
 ---
+
 
 # Section 05 — Mapping the Mind
 Course: LAB 101 – Creative Intelligence Lab I
+
+## Overview
+Mapping the Mind
+
 
 ## Learning Session
 Explore These Materials:
@@ -24,4 +30,3 @@ Explore These Materials:
 1. Mind Map — Visual map of your mind (interests, questions, sparks).  
 2. Creative Artifact — Turn one idea into a small artifact (poem, sketch, melody, design).  
 3. Reflection — Where do my ideas come from? What did mapping reveal?
-

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter02-section01
-title: "Section 01 — Logic & Reasoning (LBS 101)"
+title: Section 01 — Logic & Reasoning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 2
 section: 1
 course: LBS 101 – The Mental Gym
+description: Logic & Reasoning
 ---
+
 
 # Section 01 — Logic & Reasoning
 Course: LBS 101 – The Mental Gym
+
+## Overview
+Logic & Reasoning
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter02-section02
-title: "Section 02 — Voice & Style (LBS 105)"
+title: Section 02 — Voice & Style (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 2
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Voice & Style
 ---
+
 
 # Section 02 — Voice & Style
 Course: LBS 105 – Writing & Communication I
+
+## Overview
+Voice & Style
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-03.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter02-section03
-title: "Section 03 — Patterns & Sequences (LBS 110)"
+title: Section 03 — Patterns & Sequences (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 2
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Patterns & Sequences
 ---
+
 
 # Section 03 — Patterns & Sequences
 Course: LBS 110 – Mathematics for Modern Thinkers
+
+## Overview
+Patterns & Sequences
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-04.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter02-section04
-title: "Section 04 — Motion & Measurement (LBS 120)"
+title: Section 04 — Motion & Measurement (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 2
 section: 4
 course: LBS 120 – Physics with Lab
+description: Motion & Measurement
 ---
+
 
 # Section 04 — Motion & Measurement
 Course: LBS 120 – Physics with Lab
+
+## Overview
+Motion & Measurement
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter02-section05
-title: "Section 05 — Creative Constraints (LAB 101)"
+title: Section 05 — Creative Constraints (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 2
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Creative Constraints
 ---
+
 
 # Section 05 — Creative Constraints
 Course: LAB 101 – Creative Intelligence Lab I
+
+## Overview
+Creative Constraints
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter03-section01
-title: "Section 01 — The Examined Life (LBS 101)"
+title: Section 01 — The Examined Life (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 3
 section: 1
 course: LBS 101 – The Mental Gym
+description: The Examined Life
 ---
+
 
 # Section 01 — The Examined Life
 Course: LBS 101 – The Mental Gym
+
+## Overview
+The Examined Life
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter03-section02
-title: "Section 02 — Argument & Persuasion (LBS 105)"
+title: Section 02 — Argument & Persuasion (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 3
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Argument & Persuasion
 ---
+
 
 # Section 02 — Argument & Persuasion
 Course: LBS 105 – Writing & Communication I
+
+## Overview
+Argument & Persuasion
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-03.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter03-section03
-title: "Section 03 — Ratios & Proportions (LBS 110)"
+title: Section 03 — Ratios & Proportions (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 3
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Ratios & Proportions
 ---
+
 
 # Section 03 — Ratios & Proportions
 Course: LBS 110 – Mathematics for Modern Thinkers
+
+## Overview
+Ratios & Proportions
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-04.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter03-section04
-title: "Section 04 — Forces & Balance (LBS 120)"
+title: Section 04 — Forces & Balance (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 3
 section: 4
 course: LBS 120 – Physics with Lab
+description: Forces & Balance
 ---
+
 
 # Section 04 — Forces & Balance
 Course: LBS 120 – Physics with Lab
+
+## Overview
+Forces & Balance
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter03-section05
-title: "Section 05 — Play as Learning (LAB 101)"
+title: Section 05 — Play as Learning (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 3
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Play as Learning
 ---
+
 
 # Section 05 — Play as Learning
 Course: LAB 101 – Creative Intelligence Lab I
+
+## Overview
+Play as Learning
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter04-section01
-title: "Section 01 — Truth & Perspectives (LBS 101)"
+title: Section 01 — Truth & Perspectives (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 4
 section: 1
 course: LBS 101 – The Mental Gym
+description: Truth & Perspectives
 ---
+
 
 # Section 01 — Truth & Perspectives
 Course: LBS 101 – The Mental Gym
+
+## Overview
+Truth & Perspectives
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter04-section02
-title: "Section 02 — Structure & Flow (LBS 105)"
+title: Section 02 — Structure & Flow (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 4
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Structure & Flow
 ---
+
 
 # Section 02 — Structure & Flow
 Course: LBS 105 – Writing & Communication I
+
+## Overview
+Structure & Flow
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-03.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter04-section03
-title: "Section 03 — Infinity & Limits (LBS 110)"
+title: Section 03 — Infinity & Limits (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 4
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Infinity & Limits
 ---
+
 
 # Section 03 — Infinity & Limits
 Course: LBS 110 – Mathematics for Modern Thinkers
+
+## Overview
+Infinity & Limits
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-04.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter04-section04
-title: "Section 04 — Energy & Work (LBS 120)"
+title: Section 04 — Energy & Work (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 4
 section: 4
 course: LBS 120 – Physics with Lab
+description: Energy & Work
 ---
+
 
 # Section 04 — Energy & Work
 Course: LBS 120 – Physics with Lab
+
+## Overview
+Energy & Work
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.md
@@ -1,14 +1,20 @@
 ---
 id: vol01-chapter04-section05
-title: "Section 05 — Storytelling Through Images (LAB 101)"
+title: Section 05 — Storytelling Through Images (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 4
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Storytelling Through Images
 ---
+
 
 # Section 05 — Storytelling Through Images
 Course: LAB 101 – Creative Intelligence Lab I
+
+## Overview
+Storytelling Through Images
+
 
 ## Learning Session
 Explore These Materials:

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter05-section01
-title: "Section 01 — Rhetoric & Persuasion (LBS 101)"
+title: Section 01 — Rhetoric & Persuasion (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 5
 section: 1
 course: LBS 101 – The Mental Gym
+description: Rhetoric & Persuasion
 ---
+
 
 # Section 01 — Rhetoric & Persuasion
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Rhetoric & Persuasion
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter05-section02
-title: "Section 02 — Audience Awareness (LBS 105)"
+title: Section 02 — Audience Awareness (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 5
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Audience Awareness
 ---
+
 
 # Section 02 — Audience Awareness
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Audience Awareness
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter05-section03
-title: "Section 03 — Probability & Uncertainty (LBS 110)"
+title: Section 03 — Probability & Uncertainty (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 5
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Probability & Uncertainty
 ---
+
 
 # Section 03 — Probability & Uncertainty
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Probability & Uncertainty
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter05-section04
-title: "Section 04 — Sound & Vibration (LBS 120)"
+title: Section 04 — Sound & Vibration (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 5
 section: 4
 course: LBS 120 – Physics with Lab
+description: Sound & Vibration
 ---
+
 
 # Section 04 — Sound & Vibration
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Sound & Vibration
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter05-section05
-title: "Section 05 — Improvisation & Surprise (LAB 101)"
+title: Section 05 — Improvisation & Surprise (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 5
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Improvisation & Surprise
 ---
+
 
 # Section 05 — Improvisation & Surprise
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Improvisation & Surprise
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter06-section01
-title: "Section 01 — Writing as Clear Thinking (LBS 101)"
+title: Section 01 — Writing as Clear Thinking (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 6
 section: 1
 course: LBS 101 – The Mental Gym
+description: Writing as Clear Thinking
 ---
+
 
 # Section 01 — Writing as Clear Thinking
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing as Clear Thinking
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter06-section02
-title: "Section 02 — Writing as Clear Thinking (LBS 105)"
+title: Section 02 — Writing as Clear Thinking (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 6
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing as Clear Thinking
 ---
+
 
 # Section 02 — Writing as Clear Thinking
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing as Clear Thinking
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter06-section03
-title: "Section 03 — Statistics as Storytelling (LBS 110)"
+title: Section 03 — Statistics as Storytelling (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 6
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Statistics as Storytelling
 ---
+
 
 # Section 03 — Statistics as Storytelling
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Statistics as Storytelling
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter06-section04
-title: "Section 04 — Light & Perception (LBS 120)"
+title: Section 04 — Light & Perception (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 6
 section: 4
 course: LBS 120 – Physics with Lab
+description: Light & Perception
 ---
+
 
 # Section 04 — Light & Perception
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Light & Perception
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter06-section05
-title: "Section 05 — Sound & Rhythm (LAB 101)"
+title: Section 05 — Sound & Rhythm (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 6
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Sound & Rhythm
 ---
+
 
 # Section 05 — Sound & Rhythm
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Sound & Rhythm
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter07-section01
-title: "Section 01 — Mathematics as Language (LBS 101)"
+title: Section 01 — Mathematics as Language (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 7
 section: 1
 course: LBS 101 – The Mental Gym
+description: Mathematics as Language
 ---
+
 
 # Section 01 — Mathematics as Language
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Mathematics as Language
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter07-section02
-title: "Section 02 — Writing from Sources (LBS 105)"
+title: Section 02 — Writing from Sources (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 7
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing from Sources
 ---
+
 
 # Section 02 — Writing from Sources
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing from Sources
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter07-section03
-title: "Section 03 — Geometry in Nature (LBS 110)"
+title: Section 03 — Geometry in Nature (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 7
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Geometry in Nature
 ---
+
 
 # Section 03 — Geometry in Nature
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Geometry in Nature
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter07-section04
-title: "Section 04 — Gravity & Orbits (LBS 120)"
+title: Section 04 — Gravity & Orbits (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 7
 section: 4
 course: LBS 120 – Physics with Lab
+description: Gravity & Orbits
 ---
+
 
 # Section 04 — Gravity & Orbits
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Gravity & Orbits
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter07-section05
-title: "Section 05 — Design with Found Objects (LAB 101)"
+title: Section 05 — Design with Found Objects (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 7
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Design with Found Objects
 ---
+
 
 # Section 05 — Design with Found Objects
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Design with Found Objects
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter08-section01
-title: "Section 01 — Ethics & Moral Reasoning (LBS 101)"
+title: Section 01 — Ethics & Moral Reasoning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 8
 section: 1
 course: LBS 101 – The Mental Gym
+description: Ethics & Moral Reasoning
 ---
+
 
 # Section 01 — Ethics & Moral Reasoning
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Ethics & Moral Reasoning
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter08-section02
-title: "Section 02 — Revision as Discovery (LBS 105)"
+title: Section 02 — Revision as Discovery (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 8
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Revision as Discovery
 ---
+
 
 # Section 02 — Revision as Discovery
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Revision as Discovery
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter08-section03
-title: "Section 03 — Symmetry & Beauty (LBS 110)"
+title: Section 03 — Symmetry & Beauty (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 8
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Symmetry & Beauty
 ---
+
 
 # Section 03 — Symmetry & Beauty
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Symmetry & Beauty
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter08-section04
-title: "Section 04 — Electricity & Circuits (LBS 120)"
+title: Section 04 — Electricity & Circuits (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 8
 section: 4
 course: LBS 120 – Physics with Lab
+description: Electricity & Circuits
 ---
+
 
 # Section 04 — Electricity & Circuits
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Electricity & Circuits
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter08-section05
-title: "Section 05 — Collaboration & Exchange (LAB 101)"
+title: Section 05 — Collaboration & Exchange (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 8
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Collaboration & Exchange
 ---
+
 
 # Section 05 — Collaboration & Exchange
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Collaboration & Exchange
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter09-section01
-title: "Section 01 — Science & Inquiry (LBS 101)"
+title: Section 01 — Science & Inquiry (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 9
 section: 1
 course: LBS 101 – The Mental Gym
+description: Science & Inquiry
 ---
+
 
 # Section 01 — Science & Inquiry
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Science & Inquiry
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter09-section02
-title: "Section 02 — Storytelling in Oral Traditions (LBS 105)"
+title: Section 02 — Storytelling in Oral Traditions (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 9
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Storytelling in Oral Traditions
 ---
+
 
 # Section 02 — Storytelling in Oral Traditions
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Storytelling in Oral Traditions
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter09-section03
-title: "Section 03 — Numbers in Music (LBS 110)"
+title: Section 03 — Numbers in Music (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 9
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Numbers in Music
 ---
+
 
 # Section 03 — Numbers in Music
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Numbers in Music
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter09-section04
-title: "Section 04 — Waves in Nature (LBS 120)"
+title: Section 04 — Waves in Nature (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 9
 section: 4
 course: LBS 120 – Physics with Lab
+description: Waves in Nature
 ---
+
 
 # Section 04 — Waves in Nature
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Waves in Nature
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter09-section05
-title: "Section 05 — Creative Spaces (LAB 101)"
+title: Section 05 — Creative Spaces (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 9
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Creative Spaces
 ---
+
 
 # Section 05 — Creative Spaces
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Creative Spaces
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter10-section01
-title: "Section 01 — Imagination & Creativity (LBS 101)"
+title: Section 01 — Imagination & Creativity (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 10
 section: 1
 course: LBS 101 – The Mental Gym
+description: Imagination & Creativity
 ---
+
 
 # Section 01 — Imagination & Creativity
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Imagination & Creativity
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter10-section02
-title: "Section 02 — Writing for Media (LBS 105)"
+title: Section 02 — Writing for Media (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 10
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing for Media
 ---
+
 
 # Section 02 — Writing for Media
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing for Media
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter10-section03
-title: "Section 03 — Chaos & Complexity (LBS 110)"
+title: Section 03 — Chaos & Complexity (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 10
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Chaos & Complexity
 ---
+
 
 # Section 03 — Chaos & Complexity
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Chaos & Complexity
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter10-section04
-title: "Section 04 — Heat & Thermodynamics (LBS 120)"
+title: Section 04 — Heat & Thermodynamics (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 10
 section: 4
 course: LBS 120 – Physics with Lab
+description: Heat & Thermodynamics
 ---
+
 
 # Section 04 — Heat & Thermodynamics
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Heat & Thermodynamics
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter10-section05
-title: "Section 05 — Patterns in Chaos (LAB 101)"
+title: Section 05 — Patterns in Chaos (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 10
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Patterns in Chaos
 ---
+
 
 # Section 05 — Patterns in Chaos
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Patterns in Chaos
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter11-section01
-title: "Section 01 — Memory & Learning (LBS 101)"
+title: Section 01 — Memory & Learning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 11
 section: 1
 course: LBS 101 – The Mental Gym
+description: Memory & Learning
 ---
+
 
 # Section 01 — Memory & Learning
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Memory & Learning
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter11-section02
-title: "Section 02 — Writing & Identity (LBS 105)"
+title: Section 02 — Writing & Identity (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 11
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing & Identity
 ---
+
 
 # Section 02 — Writing & Identity
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing & Identity
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter11-section03
-title: "Section 03 — Math in Technology (LBS 110)"
+title: Section 03 — Math in Technology (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 11
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Math in Technology
 ---
+
 
 # Section 03 — Math in Technology
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Math in Technology
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter11-section04
-title: "Section 04 — Momentum & Collisions (LBS 120)"
+title: Section 04 — Momentum & Collisions (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 11
 section: 4
 course: LBS 120 – Physics with Lab
+description: Momentum & Collisions
 ---
+
 
 # Section 04 — Momentum & Collisions
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Momentum & Collisions
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter11-section05
-title: "Section 05 — Art & Technology (LAB 101)"
+title: Section 05 — Art & Technology (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 11
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Art & Technology
 ---
+
 
 # Section 05 — Art & Technology
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Art & Technology
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter12-section01
-title: "Section 01 — Culture & Worldviews (LBS 101)"
+title: Section 01 — Culture & Worldviews (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 12
 section: 1
 course: LBS 101 – The Mental Gym
+description: Culture & Worldviews
 ---
+
 
 # Section 01 — Culture & Worldviews
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Culture & Worldviews
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter12-section02
-title: "Section 02 — Writing in Community (LBS 105)"
+title: Section 02 — Writing in Community (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 12
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing in Community
 ---
+
 
 # Section 02 — Writing in Community
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing in Community
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter12-section03
-title: "Section 03 — Visualizing Data (LBS 110)"
+title: Section 03 — Visualizing Data (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 12
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Visualizing Data
 ---
+
 
 # Section 03 — Visualizing Data
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Visualizing Data
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter12-section04
-title: "Section 04 — Scale of the Universe (LBS 120)"
+title: Section 04 — Scale of the Universe (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 12
 section: 4
 course: LBS 120 – Physics with Lab
+description: Scale of the Universe
 ---
+
 
 # Section 04 — Scale of the Universe
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Scale of the Universe
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter12-section05
-title: "Section 05 — Creativity Across Cultures (LAB 101)"
+title: Section 05 — Creativity Across Cultures (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 12
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Creativity Across Cultures
 ---
+
 
 # Section 05 — Creativity Across Cultures
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Creativity Across Cultures
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter13-section01
-title: "Section 01 — Technology & Tools of Thought (LBS 101)"
+title: Section 01 — Technology & Tools of Thought (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 13
 section: 1
 course: LBS 101 – The Mental Gym
+description: Technology & Tools of Thought
 ---
+
 
 # Section 01 — Technology & Tools of Thought
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Technology & Tools of Thought
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter13-section02
-title: "Section 02 — Writing & Technology (LBS 105)"
+title: Section 02 — Writing & Technology (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 13
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing & Technology
 ---
+
 
 # Section 02 — Writing & Technology
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing & Technology
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter13-section03
-title: "Section 03 — The Philosophy of Numbers (LBS 110)"
+title: Section 03 — The Philosophy of Numbers (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 13
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: The Philosophy of Numbers
 ---
+
 
 # Section 03 — The Philosophy of Numbers
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+The Philosophy of Numbers
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter13-section04
-title: "Section 04 — Chaos & Randomness (LBS 120)"
+title: Section 04 — Chaos & Randomness (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 13
 section: 4
 course: LBS 120 – Physics with Lab
+description: Chaos & Randomness
 ---
+
 
 # Section 04 — Chaos & Randomness
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Chaos & Randomness
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter13-section05
-title: "Section 05 — Creative Risks (LAB 101)"
+title: Section 05 — Creative Risks (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 13
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Creative Risks
 ---
+
 
 # Section 05 — Creative Risks
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Creative Risks
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter14-section01
-title: "Section 01 — Philosophy of Knowledge (LBS 101)"
+title: Section 01 — Philosophy of Knowledge (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 14
 section: 1
 course: LBS 101 – The Mental Gym
+description: Philosophy of Knowledge
 ---
+
 
 # Section 01 — Philosophy of Knowledge
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Philosophy of Knowledge
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter14-section02
-title: "Section 02 — Writing as Reflection (LBS 105)"
+title: Section 02 — Writing as Reflection (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 14
 section: 2
 course: LBS 105 – Writing & Communication I
+description: Writing as Reflection
 ---
+
 
 # Section 02 — Writing as Reflection
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Writing as Reflection
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter14-section03
-title: "Section 03 — Math as Creativity (LBS 110)"
+title: Section 03 — Math as Creativity (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 14
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: Math as Creativity
 ---
+
 
 # Section 03 — Math as Creativity
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Math as Creativity
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter14-section04
-title: "Section 04 — Science & Society (LBS 120)"
+title: Section 04 — Science & Society (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 14
 section: 4
 course: LBS 120 – Physics with Lab
+description: Science & Society
 ---
+
 
 # Section 04 — Science & Society
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Science & Society
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter14-section05
-title: "Section 05 — Creative Flow (LAB 101)"
+title: Section 05 — Creative Flow (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 14
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Creative Flow
 ---
+
 
 # Section 05 — Creative Flow
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Creative Flow
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter15-section01
-title: "Section 01 — My Philosophy of Learning (LBS 101)"
+title: Section 01 — My Philosophy of Learning (LBS 101)
 parent_volume: vol-01-foundations
 chapter: 15
 section: 1
 course: LBS 101 – The Mental Gym
+description: My Philosophy of Learning
 ---
+
 
 # Section 01 — My Philosophy of Learning
 Course: LBS 101 – The Mental Gym
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+My Philosophy of Learning
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter15-section02
-title: "Section 02 — My Manifesto of Voice (LBS 105)"
+title: Section 02 — My Manifesto of Voice (LBS 105)
 parent_volume: vol-01-foundations
 chapter: 15
 section: 2
 course: LBS 105 – Writing & Communication I
+description: My Manifesto of Voice
 ---
+
 
 # Section 02 — My Manifesto of Voice
 Course: LBS 105 – Writing & Communication I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+My Manifesto of Voice
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-03.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-03.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter15-section03
-title: "Section 03 — My Math Philosophy (LBS 110)"
+title: Section 03 — My Math Philosophy (LBS 110)
 parent_volume: vol-01-foundations
 chapter: 15
 section: 3
 course: LBS 110 – Mathematics for Modern Thinkers
+description: My Math Philosophy
 ---
+
 
 # Section 03 — My Math Philosophy
 Course: LBS 110 – Mathematics for Modern Thinkers
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+My Math Philosophy
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-04.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-04.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter15-section04
-title: "Section 04 — My Philosophy of Science (LBS 120)"
+title: Section 04 — My Philosophy of Science (LBS 120)
 parent_volume: vol-01-foundations
 chapter: 15
 section: 4
 course: LBS 120 – Physics with Lab
+description: My Philosophy of Science
 ---
+
 
 # Section 04 — My Philosophy of Science
 Course: LBS 120 – Physics with Lab
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+My Philosophy of Science
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-05.md
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-05.md
@@ -1,14 +1,19 @@
 ---
 id: vol01-chapter15-section05
-title: "Section 05 — Creative Manifesto (LAB 101)"
+title: Section 05 — Creative Manifesto (LAB 101)
 parent_volume: vol-01-foundations
 chapter: 15
 section: 5
 course: LAB 101 – Creative Intelligence Lab I
+description: Creative Manifesto
 ---
+
 
 # Section 05 — Creative Manifesto
 Course: LAB 101 – Creative Intelligence Lab I
 
-Placeholder content. Add Learning Session and Practice.
+## Overview
+Creative Manifesto
 
+
+Placeholder content. Add Learning Session and Practice.

--- a/scripts/add_section_overviews.py
+++ b/scripts/add_section_overviews.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Add description field and Overview section to all section Markdown files."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+ROOT = Path(__file__).resolve().parents[1]
+SECTIONS = sorted(ROOT.glob("programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-*/section-*.md"))
+
+def desc_from_title(title: str) -> str:
+    parts = re.split(r"\s[—–-]\s", title, maxsplit=1)
+    desc = parts[1] if len(parts) > 1 else title
+    desc = re.sub(r"\s*\([^)]*\)\s*", "", desc).strip()
+    return desc
+
+def load_yaml(block: str) -> dict:
+    if yaml is not None:
+        try:
+            data = yaml.safe_load(block) or {}
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+    data: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        data[k.strip()] = v.strip().strip('"')
+    return data
+
+def dump_yaml(data: dict) -> str:
+    if yaml is not None:
+        return yaml.safe_dump(data, sort_keys=False).strip()
+    return "\n".join(f"{k}: {v}" for k, v in data.items())
+
+for path in SECTIONS:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        continue
+    fm_end = text.find("\n---", 3)
+    if fm_end == -1:
+        continue
+    fm_block = text[3:fm_end].strip()
+    body = text[fm_end + 4:]
+    data = load_yaml(fm_block)
+    title = data.get("title", "")
+    desc = data.get("description") or desc_from_title(title)
+    data.setdefault("description", desc)
+    # ensure Overview section exists
+    if "## Overview" not in body:
+        lines = body.splitlines()
+        insert_idx = 0
+        for i, line in enumerate(lines):
+            if line.strip().startswith("Course"):
+                insert_idx = i + 1
+                break
+        overview_block = ["", "## Overview", desc, ""]
+        lines[insert_idx:insert_idx] = overview_block
+        body = "\n".join(lines)
+    new_fm = "---\n" + dump_yaml(data) + "\n---\n"
+    path.write_text(new_fm + body, encoding="utf-8")

--- a/scripts/generate_programs_tree.py
+++ b/scripts/generate_programs_tree.py
@@ -105,27 +105,6 @@ def desc_from_title(title: str) -> str:
     desc = re.sub(r"\s*\([^)]*\)\s*", "", desc).strip()
     return desc
 
-def strip_tags(html: str) -> str:
-    # Remove tags
-    text = re.sub(r"<script[\s\S]*?</script>", " ", html, flags=re.I)
-    text = re.sub(r"<style[\s\S]*?</style>", " ", text, flags=re.I)
-    text = re.sub(r"<[^>]+>", " ", text)
-    # Collapse whitespace
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
-
-
-def extract_preview(section_html_path: Path, max_chars: int = 320) -> str:
-    try:
-        s = section_html_path.read_text(encoding="utf-8")
-    except Exception:
-        return ""
-    m = re.search(r"<main>([\s\S]*?)</main>", s, flags=re.I)
-    body = m.group(1) if m else s
-    text = strip_tags(body)
-    if len(text) > max_chars:
-        text = text[:max_chars].rstrip() + "…"
-    return text
 
 
 def build_tree() -> str:
@@ -146,7 +125,7 @@ def build_tree() -> str:
         desc_span = f" <span class='desc'>— {vol_desc}</span>" if vol_desc else ""
         vol_block.append(
             f"<details><summary>{vol_label}{desc_span} "
-            f"<a class='view' href='{vol_index}' aria-label='Open volume'>view</a></summary>"
+            f"<a class='view' href='{vol_index}' aria-label='Open volume'>🔗</a></summary>"
         )
         # Chapters
         sched = vol / "schedule"
@@ -162,7 +141,7 @@ def build_tree() -> str:
                     chap_desc_span = f" <span class='desc'>— {chap_desc}</span>" if chap_desc else ""
                     vol_block.append(
                         f"<li><details><summary>{chap_label}{chap_desc_span} "
-                        f"<a class='view' href='{chap_index}' aria-label='Open chapter'>view</a></summary>"
+                        f"<a class='view' href='{chap_index}' aria-label='Open chapter'>🔗</a></summary>"
                     )
                     # Sections
                     secs = sorted(chap.glob("section-*.html"), key=sect_key)
@@ -171,17 +150,13 @@ def build_tree() -> str:
                         for sec in secs:
                             sec_num = sect_key(sec)
                             sec_label = f"Section {sec_num:02d}"
-                            preview = extract_preview(sec)
-                            # Prefer section title-based description
                             sec_md = sec.with_suffix('.md')
-                            sec_title = title_from_md(sec_md) or sec_label
-                            sec_desc = desc_from_title(sec_title)
-                            section_desc = sec_desc
-                            if vol.name == "vol-01-foundations":
-                                section_desc = f"{sec_desc} ({chap_desc})"
+                            fm = read_frontmatter(sec_md)
+                            sec_title = (fm.get("title") if isinstance(fm, dict) else None) or sec_label
+                            sec_desc = (fm.get("description") if isinstance(fm, dict) else None) or desc_from_title(sec_title)
                             vol_block.append(
                                 f"<li><a href='{sec.relative_to(ROOT).as_posix()}'>{sec_label}</a> "
-                                f"<span class='desc'>— {section_desc}</span></li>"
+                                f"<span class='desc'>— {sec_desc}</span></li>"
                             )
                         vol_block.append("</ul>")
                     vol_block.append("</details></li>")


### PR DESCRIPTION
## Summary
- add description frontmatter and overview section to each Volume 1 schedule entry
- read descriptions from section frontmatter when generating index
- surface descriptions alongside sections in the homepage programs tree

## Testing
- `python scripts/generate_programs_tree.py`
- `python scripts/build_site.py --out .` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python scripts/validate.py` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68c0cd5a00ec832ebbc98ffc9d27b05f