### PR TITLE
chore: auto-build index when markdown changes

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -1,0 +1,38 @@
+name: Build Site Index
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/build_site.py'
+      - 'scripts/generate_programs_tree.py'
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml
+      - name: Build site and update index
+        run: |
+          python scripts/build_site.py --out .
+          python scripts/generate_programs_tree.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m 'chore: rebuild site index [skip ci]'
+            git push
+          fi

--- a/index.html
+++ b/index.html
@@ -119,9 +119,9 @@
     </div>
 
     <!-- PROGRAMS_TREE_START (auto-generated) -->
-<details><summary>Vol 01 Foundations <span class='desc'>— Groundwork in thinking, communication, math, science, and creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 01 Foundations <span class='desc'>— Groundwork in thinking, communication, math, science, and creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 <ul>
-<li><details><summary>Chapter 01 <span class='desc'>— The Beginning of Inquiry</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 01 <span class='desc'>— The Beginning of Inquiry</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html'>Section 01</a> <span class='desc'>— What is a Liberal Education? (The Beginning of Inquiry)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.html'>Section 02</a> <span class='desc'>— The Power of Story (The Beginning of Inquiry)</span></li>
@@ -130,7 +130,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.html'>Section 05</a> <span class='desc'>— Mapping the Mind (The Beginning of Inquiry)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 02 <span class='desc'>— Chapter 2</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 02 <span class='desc'>— Chapter 2</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.html'>Section 01</a> <span class='desc'>— Logic & Reasoning (Chapter 2)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.html'>Section 02</a> <span class='desc'>— Voice & Style (Chapter 2)</span></li>
@@ -139,7 +139,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.html'>Section 05</a> <span class='desc'>— Creative Constraints (Chapter 2)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 03 <span class='desc'>— Chapter 3</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 03 <span class='desc'>— Chapter 3</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.html'>Section 01</a> <span class='desc'>— The Examined Life (Chapter 3)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.html'>Section 02</a> <span class='desc'>— Argument & Persuasion (Chapter 3)</span></li>
@@ -148,7 +148,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.html'>Section 05</a> <span class='desc'>— Play as Learning (Chapter 3)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 04 <span class='desc'>— Chapter 4</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 04 <span class='desc'>— Chapter 4</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.html'>Section 01</a> <span class='desc'>— Truth & Perspectives (Chapter 4)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.html'>Section 02</a> <span class='desc'>— Structure & Flow (Chapter 4)</span></li>
@@ -157,7 +157,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.html'>Section 05</a> <span class='desc'>— Storytelling Through Images (Chapter 4)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 05 <span class='desc'>— Chapter 5</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 05 <span class='desc'>— Chapter 5</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.html'>Section 01</a> <span class='desc'>— Rhetoric & Persuasion (Chapter 5)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.html'>Section 02</a> <span class='desc'>— Audience Awareness (Chapter 5)</span></li>
@@ -166,7 +166,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.html'>Section 05</a> <span class='desc'>— Improvisation & Surprise (Chapter 5)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 06 <span class='desc'>— Chapter 6</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 06 <span class='desc'>— Chapter 6</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.html'>Section 01</a> <span class='desc'>— Writing as Clear Thinking (Chapter 6)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.html'>Section 02</a> <span class='desc'>— Writing as Clear Thinking (Chapter 6)</span></li>
@@ -175,7 +175,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.html'>Section 05</a> <span class='desc'>— Sound & Rhythm (Chapter 6)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 07 <span class='desc'>— Chapter 7</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 07 <span class='desc'>— Chapter 7</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.html'>Section 01</a> <span class='desc'>— Mathematics as Language (Chapter 7)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.html'>Section 02</a> <span class='desc'>— Writing from Sources (Chapter 7)</span></li>
@@ -184,7 +184,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.html'>Section 05</a> <span class='desc'>— Design with Found Objects (Chapter 7)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 08 <span class='desc'>— Chapter 8</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 08 <span class='desc'>— Chapter 8</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.html'>Section 01</a> <span class='desc'>— Ethics & Moral Reasoning (Chapter 8)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.html'>Section 02</a> <span class='desc'>— Revision as Discovery (Chapter 8)</span></li>
@@ -193,7 +193,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.html'>Section 05</a> <span class='desc'>— Collaboration & Exchange (Chapter 8)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 09 <span class='desc'>— Chapter 9</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 09 <span class='desc'>— Chapter 9</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.html'>Section 01</a> <span class='desc'>— Science & Inquiry (Chapter 9)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.html'>Section 02</a> <span class='desc'>— Storytelling in Oral Traditions (Chapter 9)</span></li>
@@ -202,7 +202,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.html'>Section 05</a> <span class='desc'>— Creative Spaces (Chapter 9)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 10 <span class='desc'>— Chapter 10</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 10 <span class='desc'>— Chapter 10</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.html'>Section 01</a> <span class='desc'>— Imagination & Creativity (Chapter 10)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.html'>Section 02</a> <span class='desc'>— Writing for Media (Chapter 10)</span></li>
@@ -211,7 +211,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.html'>Section 05</a> <span class='desc'>— Patterns in Chaos (Chapter 10)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 11 <span class='desc'>— Chapter 11</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 11 <span class='desc'>— Chapter 11</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.html'>Section 01</a> <span class='desc'>— Memory & Learning (Chapter 11)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.html'>Section 02</a> <span class='desc'>— Writing & Identity (Chapter 11)</span></li>
@@ -220,7 +220,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.html'>Section 05</a> <span class='desc'>— Art & Technology (Chapter 11)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 12 <span class='desc'>— Chapter 12</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 12 <span class='desc'>— Chapter 12</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.html'>Section 01</a> <span class='desc'>— Culture & Worldviews (Chapter 12)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.html'>Section 02</a> <span class='desc'>— Writing in Community (Chapter 12)</span></li>
@@ -229,7 +229,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.html'>Section 05</a> <span class='desc'>— Creativity Across Cultures (Chapter 12)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 13 <span class='desc'>— Chapter 13</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 13 <span class='desc'>— Chapter 13</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.html'>Section 01</a> <span class='desc'>— Technology & Tools of Thought (Chapter 13)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.html'>Section 02</a> <span class='desc'>— Writing & Technology (Chapter 13)</span></li>
@@ -238,7 +238,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.html'>Section 05</a> <span class='desc'>— Creative Risks (Chapter 13)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 14 <span class='desc'>— Chapter 14</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 14 <span class='desc'>— Chapter 14</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.html'>Section 01</a> <span class='desc'>— Philosophy of Knowledge (Chapter 14)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.html'>Section 02</a> <span class='desc'>— Writing as Reflection (Chapter 14)</span></li>
@@ -247,7 +247,7 @@
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.html'>Section 05</a> <span class='desc'>— Creative Flow (Chapter 14)</span></li>
 </ul>
 </details></li>
-<li><details><summary>Chapter 15 <span class='desc'>— Chapter 15</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>view</a></summary>
+<li><details><summary>Chapter 15 <span class='desc'>— Chapter 15</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>🔗</a></summary>
 <ul>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.html'>Section 01</a> <span class='desc'>— My Philosophy of Learning (Chapter 15)</span></li>
 <li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.html'>Section 02</a> <span class='desc'>— My Manifesto of Voice (Chapter 15)</span></li>
@@ -258,19 +258,19 @@
 </details></li>
 </ul>
 </details>
-<details><summary>Vol 02 Ethics And Reasoning <span class='desc'>— Explore moral philosophy and sharpen logical reasoning.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 02 Ethics And Reasoning <span class='desc'>— Explore moral philosophy and sharpen logical reasoning.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 03 Communication Rhetoric <span class='desc'>— Develop effective communication and persuasive skills.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 03 Communication Rhetoric <span class='desc'>— Develop effective communication and persuasive skills.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 04 Science Systems <span class='desc'>— Investigate scientific principles and complex systems.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 04 Science Systems <span class='desc'>— Investigate scientific principles and complex systems.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 05 Design Creativity <span class='desc'>— Practice design thinking to unlock creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 05 Design Creativity <span class='desc'>— Practice design thinking to unlock creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 06 Economy History <span class='desc'>— Trace economic ideas through historical contexts.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 06 Economy History <span class='desc'>— Trace economic ideas through historical contexts.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 07 Technology Society <span class='desc'>— Examine technology's role in shaping society.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 07 Technology Society <span class='desc'>— Examine technology's role in shaping society.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
-<details><summary>Vol 08 Leadership Citizenship <span class='desc'>— Build leadership skills and civic responsibility.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html' aria-label='Open volume'>view</a></summary>
+<details><summary>Vol 08 Leadership Citizenship <span class='desc'>— Build leadership skills and civic responsibility.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html' aria-label='Open volume'>🔗</a></summary>
 </details>
     <!-- PROGRAMS_TREE_END -->
 </main>

--- a/scripts/generate_programs_tree.py
+++ b/scripts/generate_programs_tree.py
@@ -146,7 +146,7 @@ def build_tree() -> str:
         desc_span = f" <span class='desc'>— {vol_desc}</span>" if vol_desc else ""
         vol_block.append(
             f"<details><summary>{vol_label}{desc_span} "
-            f"<a class='view' href='{vol_index}' aria-label='Open volume'>view</a></summary>"
+            f"<a class='view' href='{vol_index}' aria-label='Open volume'>🔗</a></summary>"
         )
         # Chapters
         sched = vol / "schedule"
@@ -166,7 +166,7 @@ def build_tree() -> str:
                     chap_desc_span = f" <span class='desc'>— {chap_desc}</span>" if chap_desc else ""
                     vol_block.append(
                         f"<li><details><summary>{chap_label}{chap_desc_span} "
-                        f"<a class='view' href='{chap_index}' aria-label='Open chapter'>view</a></summary>"
+                        f"<a class='view' href='{chap_index}' aria-label='Open chapter'>🔗</a></summary>"
                     )
                     # Sections
                     secs = sorted(chap.glob("section-*.html"), key=sect_key)
@@ -218,7 +218,13 @@ def inject_into_index(html_block: str) -> None:
         )
     else:
         eidx += len(end)
-        new = content[:sidx] + f"<!-- PROGRAMS_TREE_START (auto-generated) -->\n" + html_block + "\n" + content[eidx:]
+        new = (
+            content[:sidx]
+            + "<!-- PROGRAMS_TREE_START (auto-generated) -->\n"
+            + html_block
+            + "\n    <!-- PROGRAMS_TREE_END -->"
+            + content[eidx:]
+        )
     INDEX_HTML.write_text(new, encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
- add GitHub Action that rebuilds the site index whenever markdown files change
- use link icon and keep end marker when injecting programs tree

## Testing
- `python scripts/generate_programs_tree.py`
- `python scripts/validate.py` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68c18ab97a0c832ebde83636c38d7c15