### PR TITLE
ci: rebuild site on YAML changes

### DIFF
--- a/.github/workflows/build-index.yml
+++ b/.github/workflows/build-index.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '**/*.md'
+      - '**/*.yml'
+      - '**/*.yaml'
       - 'scripts/build_site.py'
       - 'scripts/generate_programs_tree.py'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Schema: A formal schema is not enforced yet. If you add structure that others wi
 
 - Write public content in Markdown.
 - Keep pages short and scannable; link to deeper details in `knowledge/` when appropriate.
-- There is no static site generator configured yet in this repo. You can render directly on GitHub, or add a site tool (e.g., MkDocs) in a future change.
+- A minimal static site builder (`scripts/build_site.py`) runs in GitHub Actions to regenerate HTML so the published site mirrors the Markdown and YAML sources.
 
 ---
 


### PR DESCRIPTION
## Summary
- rebuild site automatically when YAML/YML files change
- document that the GitHub Action regenerates HTML to match Markdown and YAML sources

## Testing
- `python scripts/validate.py` *(fails: No module named 'yaml')*
- `python scripts/build_site.py --out .` *(fails: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68c6c902f844832ea3ae8d1249fd8376