### PR TITLE
Implement shared layout and chapter navigation

### DIFF
--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -1,0 +1,37 @@
+// Lightweight client-side includes for header/footer partials
+(function() {
+  async function include(el) {
+    const src = el.getAttribute('data-include');
+    if (!src) return;
+    try {
+      const res = await fetch(src, { credentials: 'same-origin' });
+      if (!res.ok) throw new Error('Failed to fetch ' + src);
+      const html = await res.text();
+      el.innerHTML = html;
+      // Execute any scripts inside the included HTML
+      const scripts = el.querySelectorAll('script');
+      scripts.forEach(old => {
+        const s = document.createElement('script');
+        // Copy attributes (e.g., src, type, defer)
+        for (const a of old.attributes) s.setAttribute(a.name, a.value);
+        s.text = old.textContent;
+        // Use head for external scripts, body for inline
+        (s.src ? document.head : document.body).appendChild(s);
+        old.remove();
+      });
+    } catch (e) {
+      console.error('Include failed:', src, e);
+    }
+  }
+
+  async function run() {
+    const nodes = document.querySelectorAll('[data-include]');
+    await Promise.all(Array.from(nodes).map(include));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+})();

--- a/assets/js/layout.js
+++ b/assets/js/layout.js
@@ -1,0 +1,36 @@
+// Enhance chapter and section lists into card grids
+(function() {
+  function wrapAsGrid(items) {
+    if (!items.length) return;
+    // Don't re-wrap if already inside a .cards-grid
+    const first = items[0];
+    const parent = first.parentElement;
+    if (parent && parent.classList.contains('cards-grid')) return;
+
+    const grid = document.createElement('div');
+    grid.className = 'cards-grid';
+    // Insert grid before the first item
+    parent.insertBefore(grid, first);
+    // Move all sibling items with the same class into the grid
+    const list = Array.from(parent.querySelectorAll(`.${first.className.split(' ').join('.')}, .section-item, .chapter-item`));
+    // Filter to only direct children of parent to avoid moving nested sections
+    const direct = list.filter(el => el.parentElement === parent);
+    direct.forEach(el => grid.appendChild(el));
+  }
+
+  function enhance() {
+    // Chapter lists
+    const chapters = document.querySelectorAll('.chapter-item');
+    if (chapters.length) wrapAsGrid(Array.from(chapters));
+
+    // Section lists
+    const sections = document.querySelectorAll('.section-item');
+    if (sections.length) wrapAsGrid(Array.from(sections));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', enhance);
+  } else {
+    enhance();
+  }
+})();

--- a/assets/js/metrics.js
+++ b/assets/js/metrics.js
@@ -1,0 +1,16 @@
+(function() {
+  function run() {
+    try {
+      const nav = performance.getEntriesByType('navigation')[0];
+      const loadMs = nav ? Math.round(nav.domComplete - nav.startTime) : Math.round(performance.now());
+      const bytes = new TextEncoder().encode(document.documentElement.outerHTML).length;
+      const kb = (bytes / 1024).toFixed(1);
+      const links = document.querySelectorAll('a').length;
+      const stamp = new Date().toLocaleString();
+      const el = document.getElementById('metrics');
+      if (el) el.textContent = `Load Time: ${loadMs} ms · Page Size: ${kb} KB · Links: ${links} · ${stamp}`;
+    } catch (e) {}
+  }
+  if (document.readyState === 'complete') run();
+  else window.addEventListener('load', run);
+})();

--- a/assets/site.css
+++ b/assets/site.css
@@ -1,0 +1,106 @@
+/* SDIT site-wide light theme and layout */
+:root {
+  --ink: #111;
+  --bg: #fff;
+  --muted: #666;
+  --card: #f9f9f9;
+  --border: #e0e0e0;
+  --link: #0366d6;
+  --highlight: #f3f4f6;
+}
+* { box-sizing: border-box; }
+html { font-size: 16px; }
+body {
+  margin: 0;
+  font-family: -apple-system, Segoe UI, Roboto, Inter, system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.65;
+}
+
+/* Header & Footer */
+header.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--highlight);
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+header.site-header h1 { margin: 0; font-size: 24px; font-weight: 700; }
+header.site-header nav a { margin-left: 20px; font-size: 16px; color: var(--link); text-decoration: none; }
+header.site-header nav a:hover { text-decoration: underline; }
+
+footer.site-footer {
+  margin-top: 60px;
+  text-align: center;
+  padding: 30px;
+  font-size: 14px;
+  color: var(--muted);
+  background: var(--highlight);
+  border-top: 1px solid var(--border);
+}
+
+/* Main content */
+main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
+.hero { text-align: center; margin-bottom: 40px; }
+.hero h2 { font-size: 32px; margin-bottom: 10px; }
+.hero p { font-size: 18px; color: var(--muted); margin-bottom: 20px; }
+.cta-buttons { display: flex; justify-content: center; gap: 20px; flex-wrap: wrap; margin-bottom: 20px; }
+.btn { display: inline-block; padding: 10px 20px; background: var(--link); color: #fff; border-radius: 8px; text-decoration: none; font-weight: 500; }
+.btn:hover { opacity: 0.9; }
+
+/* Search bar */
+.search-bar { max-width: 420px; margin: 0 auto 24px; }
+.search-bar input { width: 100%; padding: 10px; border: 1px solid var(--border); border-radius: 8px; font-size: 16px; }
+
+/* Breadcrumbs */
+.breadcrumbs { font-size: 14px; color: var(--muted); margin: 6px 0 16px; }
+.breadcrumbs a { color: var(--muted); text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; color: var(--ink); }
+.breadcrumbs .sep { margin: 0 6px; color: var(--border); }
+
+/* Cards and grids */
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; }
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+}
+.card h3 { margin: 8px 0 6px; font-size: 18px; }
+.card .tagline, .card .desc { color: var(--muted); font-size: 14px; }
+.card .icon { font-size: 32px; }
+.card .card-actions { margin-top: 12px; display: flex; gap: 10px; }
+
+/* Volume cards (home) */
+.volume-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
+.volume-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 20px; text-align: center; }
+.volume-card .icon { font-size: 36px; margin-bottom: 10px; }
+.volume-card h3 { margin: 10px 0; font-size: 20px; }
+.volume-card .tagline { color: var(--muted); font-size: 15px; margin-bottom: 20px; }
+
+/* Chapters and Sections as cards */
+.cards-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; }
+.cards-grid .chapter-item, .cards-grid .section-item {
+  list-style: none;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+}
+.cards-grid .chapter-item a, .cards-grid .section-item a { color: var(--link); text-decoration: none; font-weight: 600; }
+.cards-grid .chapter-item a:hover, .cards-grid .section-item a:hover { text-decoration: underline; }
+.cards-grid .section-meta { color: var(--muted); font-size: 14px; margin-top: 6px; }
+
+@media (max-width: 768px) {
+  main { padding: 20px 16px; }
+  header.site-header { flex-direction: column; align-items: flex-start; }
+  header.site-header nav { margin-top: 10px; }
+  header.site-header h1 { font-size: 22px; }
+  .hero h2 { font-size: 26px; }
+  .hero p { font-size: 16px; }
+}

--- a/index.html
+++ b/index.html
@@ -93,49 +93,49 @@
     <section id="volumes" class="volume-grid">
       <div class="volume-card">
         <div class="icon">📚</div>
-        <h3>Volume 01: Foundations</h3>
+        <h3>Volume 1: Foundations</h3>
         <p class="tagline">Groundwork in thinking, communication, math, science, and creativity.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">⚖️</div>
-        <h3>Volume 02: Ethics &amp; Reasoning</h3>
+        <h3>Volume 2: Ethics &amp; Reasoning</h3>
         <p class="tagline">Explore moral philosophy and sharpen logical reasoning.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🗣️</div>
-        <h3>Volume 03: Communication Rhetoric</h3>
+        <h3>Volume 3: Communication Rhetoric</h3>
         <p class="tagline">Develop effective communication and persuasive skills.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🔬</div>
-        <h3>Volume 04: Science Systems</h3>
+        <h3>Volume 4: Science Systems</h3>
         <p class="tagline">Investigate scientific principles and complex systems.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🎨</div>
-        <h3>Volume 05: Design Creativity</h3>
+        <h3>Volume 5: Design Creativity</h3>
         <p class="tagline">Practice design thinking to unlock creativity.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">📈</div>
-        <h3>Volume 06: Economy History</h3>
+        <h3>Volume 6: Economy History</h3>
         <p class="tagline">Trace economic ideas through historical contexts.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">💻</div>
-        <h3>Volume 07: Technology Society</h3>
+        <h3>Volume 7: Technology Society</h3>
         <p class="tagline">Examine technology's role in shaping society.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🌟</div>
-        <h3>Volume 08: Leadership Citizenship</h3>
+        <h3>Volume 8: Leadership Citizenship</h3>
         <p class="tagline">Build leadership skills and civic responsibility.</p>
         <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html">View Chapters</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -4,85 +4,26 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SDIT Curriculum — Learn</title>
-  <style>
-    :root {
-      --ink: #111;
-      --bg: #fff;
-      --muted: #666;
-      --card: #f9f9f9;
-      --border: #e0e0e0;
-      --link: #0366d6;
-      --highlight: #f3f4f6;
-    }
-    * { box-sizing: border-box; }
-    body { margin: 0; font-family: -apple-system, Segoe UI, Roboto, Inter, system-ui, sans-serif; background: var(--bg); color: var(--ink); line-height: 1.65; }
-    header { display: flex; justify-content: space-between; align-items: center; padding: 20px; border-bottom: 1px solid var(--border); background: var(--highlight); position: sticky; top: 0; z-index: 999; }
-    header h1 { margin: 0; font-size: 24px; font-weight: 700; }
-    nav a { margin-left: 20px; font-size: 16px; color: var(--link); text-decoration: none; }
-    nav a:hover { text-decoration: underline; }
-    main { padding: 40px 20px; max-width: 960px; margin: 0 auto; }
-    .hero { text-align: center; margin-bottom: 40px; }
-    .hero h2 { font-size: 32px; margin-bottom: 10px; }
-    .hero p { font-size: 18px; color: var(--muted); margin-bottom: 20px; }
-    .cta-buttons { display: flex; justify-content: center; gap: 20px; flex-wrap: wrap; margin-bottom: 20px; }
-    .btn { display: inline-block; padding: 10px 20px; background: var(--link); color: #fff; border-radius: 8px; text-decoration: none; font-weight: 500; }
-    .btn:hover { opacity: 0.9; }
-    .search-bar { max-width: 400px; margin: 0 auto 40px; }
-    .search-bar input { width: 100%; padding: 10px; border: 1px solid var(--border); border-radius: 8px; font-size: 16px; }
-    .volume-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
-    .volume-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 20px; text-align: center; }
-    .volume-card .icon { font-size: 36px; margin-bottom: 10px; }
-    .volume-card h3 { margin: 10px 0; font-size: 20px; }
-    .volume-card .tagline { color: var(--muted); font-size: 15px; margin-bottom: 20px; }
-    footer { margin-top: 60px; text-align: center; padding: 30px; font-size: 14px; color: var(--muted); background: var(--highlight); border-top: 1px solid var(--border); }
-    @media (max-width: 768px) {
-      main { padding: 20px 16px; }
-      header { flex-direction: column; align-items: flex-start; }
-      nav { margin-top: 10px; }
-      header h1 { font-size: 22px; }
-      .hero h2 { font-size: 26px; }
-      .hero p { font-size: 16px; }
-    }
-  </style>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
   <script>
     function filterCards(event) {
       const query = event.target.value.toLowerCase();
       document.querySelectorAll('.volume-card').forEach(card => {
         const text = card.innerText.toLowerCase();
-        card.style.display = text.includes(query) ? 'block' : 'none';
+        card.style.display = text.includes(query) ? '' : 'none';
       });
     }
-    window.addEventListener('load', () => {
-      try {
-        const nav = performance.getEntriesByType('navigation')[0];
-        const loadMs = nav ? Math.round(nav.domComplete - nav.startTime) : Math.round(performance.now());
-        const bytes = new TextEncoder().encode(document.documentElement.outerHTML).length;
-        const kb = (bytes/1024).toFixed(1);
-        const links = document.querySelectorAll('a').length;
-        const stamp = new Date().toLocaleString();
-        const el = document.getElementById('metrics');
-        if (el) el.textContent = `Load Time: ${loadMs} ms · Page Size: ${kb} KB · Links: ${links} · ${stamp}`;
-      } catch(e) {}
-    });
   </script>
 </head>
 <body>
-  <header>
-    <h1>San Diego Institute of Technology</h1>
-    <nav>
-      <a href="https://www.sandiegotech.org">Home</a>
-      <a href="https://github.com/sandiegotech/sdit">GitHub</a>
-      <a href="https://www.sandiegotech.org/donate">Donate</a>
-      <a href="#volumes">Browse Volumes</a>
-      <a href="#search">Search</a>
-    </nav>
-  </header>
+  <div data-include="/partials/header.html"></div>
   <main>
     <section class="hero">
       <h2>SDIT Open Curriculum</h2>
       <p>A free, open-source education for the curious, creative, and ambitious.</p>
       <div class="cta-buttons">
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html">Start Here</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Start Here</a>
         <a class="btn" href="#volumes">Browse Volumes</a>
         <a class="btn" href="#search">Search</a>
       </div>
@@ -95,55 +36,52 @@
         <div class="icon">📚</div>
         <h3>Volume 1: Foundations</h3>
         <p class="tagline">Groundwork in thinking, communication, math, science, and creativity.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">⚖️</div>
         <h3>Volume 2: Ethics &amp; Reasoning</h3>
         <p class="tagline">Explore moral philosophy and sharpen logical reasoning.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🗣️</div>
         <h3>Volume 3: Communication Rhetoric</h3>
         <p class="tagline">Develop effective communication and persuasive skills.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🔬</div>
         <h3>Volume 4: Science Systems</h3>
         <p class="tagline">Investigate scientific principles and complex systems.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🎨</div>
         <h3>Volume 5: Design Creativity</h3>
         <p class="tagline">Practice design thinking to unlock creativity.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">📈</div>
         <h3>Volume 6: Economy History</h3>
         <p class="tagline">Trace economic ideas through historical contexts.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">💻</div>
         <h3>Volume 7: Technology Society</h3>
         <p class="tagline">Examine technology's role in shaping society.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
         <div class="icon">🌟</div>
         <h3>Volume 8: Leadership Citizenship</h3>
         <p class="tagline">Build leadership skills and civic responsibility.</p>
-        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html">View Chapters</a>
+        <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html">View Chapters</a>
       </div>
     </section>
   </main>
-  <footer>
-    <p>Built with purpose by <strong>SDIT</strong>. <a href="https://github.com/sandiegotech/sdit">View on GitHub</a> · <a href="https://www.sandiegotech.org">Main Site</a></p>
-    <p id="metrics">&nbsp;</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,72 +21,37 @@
     nav a { margin-left: 20px; font-size: 16px; color: var(--link); text-decoration: none; }
     nav a:hover { text-decoration: underline; }
     main { padding: 40px 20px; max-width: 960px; margin: 0 auto; }
-    p.description { font-size: 18px; margin-bottom: 30px; color: var(--muted); }
-    details { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 12px 18px; margin: 16px 0; transition: background 0.2s ease; }
-    details:hover { background: #fefefe; }
-    details > summary { cursor: pointer; font-weight: 600; list-style: none; position: relative; padding-left: 1.5em; font-size: 18px; }
-    details > summary::-webkit-details-marker { display: none; }
-    details > summary::marker { content: ""; }
-    details > summary::before { content: "▸"; position: absolute; left: 0; top: 0; font-size: 16px; color: var(--muted); transition: transform 0.2s ease; }
-    details[open] > summary::before { content: "▾"; }
-    details ul { margin: 10px 0 0 20px; padding-left: 0; }
-    li { margin: 6px 0; font-size: 16px; }
-    a { color: var(--link); text-decoration: none; }
-    a:hover { text-decoration: underline; }
-    .view { margin-left: 8px; font-weight: 500; font-size: 15px; }
-    .desc { color: var(--muted); font-size: 15px; }
-    .preview { color: var(--muted); font-size: 15px; margin-top: 4px; }
-    footer { margin-top: 60px; text-align: center; padding: 30px; font-size: 14px; color: var(--muted); background: var(--highlight); border-top: 1px solid var(--border); }
-    .search-bar { max-width: 400px; margin: 0 auto 30px; }
+    .hero { text-align: center; margin-bottom: 40px; }
+    .hero h2 { font-size: 32px; margin-bottom: 10px; }
+    .hero p { font-size: 18px; color: var(--muted); margin-bottom: 20px; }
+    .cta-buttons { display: flex; justify-content: center; gap: 20px; flex-wrap: wrap; margin-bottom: 20px; }
+    .btn { display: inline-block; padding: 10px 20px; background: var(--link); color: #fff; border-radius: 8px; text-decoration: none; font-weight: 500; }
+    .btn:hover { opacity: 0.9; }
+    .search-bar { max-width: 400px; margin: 0 auto 40px; }
     .search-bar input { width: 100%; padding: 10px; border: 1px solid var(--border); border-radius: 8px; font-size: 16px; }
+    .volume-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
+    .volume-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 20px; text-align: center; }
+    .volume-card .icon { font-size: 36px; margin-bottom: 10px; }
+    .volume-card h3 { margin: 10px 0; font-size: 20px; }
+    .volume-card .tagline { color: var(--muted); font-size: 15px; margin-bottom: 20px; }
+    footer { margin-top: 60px; text-align: center; padding: 30px; font-size: 14px; color: var(--muted); background: var(--highlight); border-top: 1px solid var(--border); }
     @media (max-width: 768px) {
       main { padding: 20px 16px; }
       header { flex-direction: column; align-items: flex-start; }
       nav { margin-top: 10px; }
       header h1 { font-size: 22px; }
-      p.description { font-size: 16px; }
+      .hero h2 { font-size: 26px; }
+      .hero p { font-size: 16px; }
     }
   </style>
   <script>
-    function filterDetails(event) {
+    function filterCards(event) {
       const query = event.target.value.toLowerCase();
-      const blocks = document.querySelectorAll("details");
-      blocks.forEach(d => {
-        const text = d.innerText.toLowerCase();
-        const match = text.includes(query);
-        d.style.display = match || !query ? "block" : "none";
-        d.open = query && match;
-        if (match) {
-          let parent = d.parentElement;
-          while (parent) {
-            if (parent.tagName === "DETAILS") {
-              parent.style.display = "block";
-              parent.open = true;
-            }
-            parent = parent.parentElement;
-          }
-        } else if (!query) {
-          d.open = false;
-        }
-      });
-      highlightMatches(query);
-    }
-
-    function highlightMatches(query) {
-      // Remove previous highlights
-      document.querySelectorAll('mark').forEach(m => {
-        const parent = m.parentNode;
-        parent.replaceChild(document.createTextNode(m.textContent), m);
-        parent.normalize();
-      });
-      if (!query) return;
-      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const re = new RegExp(`(${escaped})`, 'gi');
-      document.querySelectorAll('summary, a, .desc').forEach(el => {
-        el.innerHTML = el.textContent.replace(re, '<mark>$1</mark>');
+      document.querySelectorAll('.volume-card').forEach(card => {
+        const text = card.innerText.toLowerCase();
+        card.style.display = text.includes(query) ? 'block' : 'none';
       });
     }
-    // Footer metrics (load time, page size, links)
     window.addEventListener('load', () => {
       try {
         const nav = performance.getEntriesByType('navigation')[0];
@@ -108,172 +73,74 @@
       <a href="https://www.sandiegotech.org">Home</a>
       <a href="https://github.com/sandiegotech/sdit">GitHub</a>
       <a href="https://www.sandiegotech.org/donate">Donate</a>
+      <a href="#volumes">Browse Volumes</a>
+      <a href="#search">Search</a>
     </nav>
   </header>
   <main>
-    <p class="description">
-      Welcome to the SDIT Open Curriculum — a free, open-source education program for the curious, creative, and ambitious.
-    </p>
-    <div class="search-bar">
-      <input type="text" placeholder="Search volumes or chapters..." oninput="filterDetails(event)">
+    <section class="hero">
+      <h2>SDIT Open Curriculum</h2>
+      <p>A free, open-source education for the curious, creative, and ambitious.</p>
+      <div class="cta-buttons">
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html">Start Here</a>
+        <a class="btn" href="#volumes">Browse Volumes</a>
+        <a class="btn" href="#search">Search</a>
+      </div>
+    </section>
+    <div class="search-bar" id="search">
+      <input type="search" placeholder="Search volumes" oninput="filterCards(event)" />
     </div>
-
-    <!-- PROGRAMS_TREE_START (auto-generated) -->
-<details><summary>Vol 01 Foundations <span class='desc'>— Groundwork in thinking, communication, math, science, and creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-<ul>
-<li><details><summary>Chapter 01 <span class='desc'>— The Beginning of Inquiry</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html'>Section 01</a> <span class='desc'>— What is a Liberal Education? (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-02.html'>Section 02</a> <span class='desc'>— The Power of Story (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-03.html'>Section 03</a> <span class='desc'>— Mathematics as a Language (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-04.html'>Section 04</a> <span class='desc'>— Observing the Natural World (The Beginning of Inquiry)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-05.html'>Section 05</a> <span class='desc'>— Mapping the Mind (The Beginning of Inquiry)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 02 <span class='desc'>— Chapter 2</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-01.html'>Section 01</a> <span class='desc'>— Logic & Reasoning (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-02.html'>Section 02</a> <span class='desc'>— Voice & Style (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-03.html'>Section 03</a> <span class='desc'>— Patterns & Sequences (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-04.html'>Section 04</a> <span class='desc'>— Motion & Measurement (Chapter 2)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/section-05.html'>Section 05</a> <span class='desc'>— Creative Constraints (Chapter 2)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 03 <span class='desc'>— Chapter 3</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-01.html'>Section 01</a> <span class='desc'>— The Examined Life (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-02.html'>Section 02</a> <span class='desc'>— Argument & Persuasion (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-03.html'>Section 03</a> <span class='desc'>— Ratios & Proportions (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-04.html'>Section 04</a> <span class='desc'>— Forces & Balance (Chapter 3)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/section-05.html'>Section 05</a> <span class='desc'>— Play as Learning (Chapter 3)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 04 <span class='desc'>— Chapter 4</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-01.html'>Section 01</a> <span class='desc'>— Truth & Perspectives (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-02.html'>Section 02</a> <span class='desc'>— Structure & Flow (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-03.html'>Section 03</a> <span class='desc'>— Infinity & Limits (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-04.html'>Section 04</a> <span class='desc'>— Energy & Work (Chapter 4)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/section-05.html'>Section 05</a> <span class='desc'>— Storytelling Through Images (Chapter 4)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 05 <span class='desc'>— Chapter 5</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-01.html'>Section 01</a> <span class='desc'>— Rhetoric & Persuasion (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-02.html'>Section 02</a> <span class='desc'>— Audience Awareness (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-03.html'>Section 03</a> <span class='desc'>— Probability & Uncertainty (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-04.html'>Section 04</a> <span class='desc'>— Sound & Vibration (Chapter 5)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/section-05.html'>Section 05</a> <span class='desc'>— Improvisation & Surprise (Chapter 5)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 06 <span class='desc'>— Chapter 6</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-01.html'>Section 01</a> <span class='desc'>— Writing as Clear Thinking (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-02.html'>Section 02</a> <span class='desc'>— Writing as Clear Thinking (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-03.html'>Section 03</a> <span class='desc'>— Statistics as Storytelling (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-04.html'>Section 04</a> <span class='desc'>— Light & Perception (Chapter 6)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-06/section-05.html'>Section 05</a> <span class='desc'>— Sound & Rhythm (Chapter 6)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 07 <span class='desc'>— Chapter 7</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-01.html'>Section 01</a> <span class='desc'>— Mathematics as Language (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-02.html'>Section 02</a> <span class='desc'>— Writing from Sources (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-03.html'>Section 03</a> <span class='desc'>— Geometry in Nature (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-04.html'>Section 04</a> <span class='desc'>— Gravity & Orbits (Chapter 7)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-07/section-05.html'>Section 05</a> <span class='desc'>— Design with Found Objects (Chapter 7)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 08 <span class='desc'>— Chapter 8</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-01.html'>Section 01</a> <span class='desc'>— Ethics & Moral Reasoning (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-02.html'>Section 02</a> <span class='desc'>— Revision as Discovery (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-03.html'>Section 03</a> <span class='desc'>— Symmetry & Beauty (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-04.html'>Section 04</a> <span class='desc'>— Electricity & Circuits (Chapter 8)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-08/section-05.html'>Section 05</a> <span class='desc'>— Collaboration & Exchange (Chapter 8)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 09 <span class='desc'>— Chapter 9</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-01.html'>Section 01</a> <span class='desc'>— Science & Inquiry (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-02.html'>Section 02</a> <span class='desc'>— Storytelling in Oral Traditions (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-03.html'>Section 03</a> <span class='desc'>— Numbers in Music (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-04.html'>Section 04</a> <span class='desc'>— Waves in Nature (Chapter 9)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-09/section-05.html'>Section 05</a> <span class='desc'>— Creative Spaces (Chapter 9)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 10 <span class='desc'>— Chapter 10</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-01.html'>Section 01</a> <span class='desc'>— Imagination & Creativity (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-02.html'>Section 02</a> <span class='desc'>— Writing for Media (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-03.html'>Section 03</a> <span class='desc'>— Chaos & Complexity (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-04.html'>Section 04</a> <span class='desc'>— Heat & Thermodynamics (Chapter 10)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-10/section-05.html'>Section 05</a> <span class='desc'>— Patterns in Chaos (Chapter 10)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 11 <span class='desc'>— Chapter 11</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-01.html'>Section 01</a> <span class='desc'>— Memory & Learning (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-02.html'>Section 02</a> <span class='desc'>— Writing & Identity (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-03.html'>Section 03</a> <span class='desc'>— Math in Technology (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-04.html'>Section 04</a> <span class='desc'>— Momentum & Collisions (Chapter 11)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-11/section-05.html'>Section 05</a> <span class='desc'>— Art & Technology (Chapter 11)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 12 <span class='desc'>— Chapter 12</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-01.html'>Section 01</a> <span class='desc'>— Culture & Worldviews (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-02.html'>Section 02</a> <span class='desc'>— Writing in Community (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-03.html'>Section 03</a> <span class='desc'>— Visualizing Data (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-04.html'>Section 04</a> <span class='desc'>— Scale of the Universe (Chapter 12)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-12/section-05.html'>Section 05</a> <span class='desc'>— Creativity Across Cultures (Chapter 12)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 13 <span class='desc'>— Chapter 13</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-01.html'>Section 01</a> <span class='desc'>— Technology & Tools of Thought (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-02.html'>Section 02</a> <span class='desc'>— Writing & Technology (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-03.html'>Section 03</a> <span class='desc'>— The Philosophy of Numbers (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-04.html'>Section 04</a> <span class='desc'>— Chaos & Randomness (Chapter 13)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-13/section-05.html'>Section 05</a> <span class='desc'>— Creative Risks (Chapter 13)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 14 <span class='desc'>— Chapter 14</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-01.html'>Section 01</a> <span class='desc'>— Philosophy of Knowledge (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-02.html'>Section 02</a> <span class='desc'>— Writing as Reflection (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-03.html'>Section 03</a> <span class='desc'>— Math as Creativity (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-04.html'>Section 04</a> <span class='desc'>— Science & Society (Chapter 14)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-14/section-05.html'>Section 05</a> <span class='desc'>— Creative Flow (Chapter 14)</span></li>
-</ul>
-</details></li>
-<li><details><summary>Chapter 15 <span class='desc'>— Chapter 15</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/index.html' aria-label='Open chapter'>🔗</a></summary>
-<ul>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-01.html'>Section 01</a> <span class='desc'>— My Philosophy of Learning (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-02.html'>Section 02</a> <span class='desc'>— My Manifesto of Voice (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-03.html'>Section 03</a> <span class='desc'>— My Math Philosophy (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-04.html'>Section 04</a> <span class='desc'>— My Philosophy of Science (Chapter 15)</span></li>
-<li><a href='programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-15/section-05.html'>Section 05</a> <span class='desc'>— Creative Manifesto (Chapter 15)</span></li>
-</ul>
-</details></li>
-</ul>
-</details>
-<details><summary>Vol 02 Ethics And Reasoning <span class='desc'>— Explore moral philosophy and sharpen logical reasoning.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-<details><summary>Vol 03 Communication Rhetoric <span class='desc'>— Develop effective communication and persuasive skills.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-<details><summary>Vol 04 Science Systems <span class='desc'>— Investigate scientific principles and complex systems.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-<details><summary>Vol 05 Design Creativity <span class='desc'>— Practice design thinking to unlock creativity.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-<details><summary>Vol 06 Economy History <span class='desc'>— Trace economic ideas through historical contexts.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-<details><summary>Vol 07 Technology Society <span class='desc'>— Examine technology's role in shaping society.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-<details><summary>Vol 08 Leadership Citizenship <span class='desc'>— Build leadership skills and civic responsibility.</span> <a class='view' href='programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html' aria-label='Open volume'>🔗</a></summary>
-</details>
-    <!-- PROGRAMS_TREE_END -->
-</main>
+    <section id="volumes" class="volume-grid">
+      <div class="volume-card">
+        <div class="icon">📚</div>
+        <h3>Volume 01: Foundations</h3>
+        <p class="tagline">Groundwork in thinking, communication, math, science, and creativity.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-01-foundations/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">⚖️</div>
+        <h3>Volume 02: Ethics &amp; Reasoning</h3>
+        <p class="tagline">Explore moral philosophy and sharpen logical reasoning.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">🗣️</div>
+        <h3>Volume 03: Communication Rhetoric</h3>
+        <p class="tagline">Develop effective communication and persuasive skills.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">🔬</div>
+        <h3>Volume 04: Science Systems</h3>
+        <p class="tagline">Investigate scientific principles and complex systems.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">🎨</div>
+        <h3>Volume 05: Design Creativity</h3>
+        <p class="tagline">Practice design thinking to unlock creativity.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">📈</div>
+        <h3>Volume 06: Economy History</h3>
+        <p class="tagline">Trace economic ideas through historical contexts.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">💻</div>
+        <h3>Volume 07: Technology Society</h3>
+        <p class="tagline">Examine technology's role in shaping society.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon">🌟</div>
+        <h3>Volume 08: Leadership Citizenship</h3>
+        <p class="tagline">Build leadership skills and civic responsibility.</p>
+        <a class="btn" href="programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html">View Chapters</a>
+      </div>
+    </section>
+  </main>
   <footer>
     <p>Built with purpose by <strong>SDIT</strong>. <a href="https://github.com/sandiegotech/sdit">View on GitHub</a> · <a href="https://www.sandiegotech.org">Main Site</a></p>
     <p id="metrics">&nbsp;</p>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,5 @@
+<footer class="site-footer">
+  <p>Built with purpose by <strong>SDIT</strong>. <a href="https://github.com/sandiegotech/sdit">View on GitHub</a> · <a href="https://www.sandiegotech.org">Main Site</a></p>
+  <p id="metrics">&nbsp;</p>
+</footer>
+<script src="/assets/js/metrics.js" defer></script>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,11 @@
+<header class="site-header">
+  <h1>San Diego Institute of Technology</h1>
+  <nav>
+    <a href="/index.html">Home</a>
+    <a href="https://github.com/sandiegotech/sdit">GitHub</a>
+    <a href="https://www.sandiegotech.org/donate">Donate</a>
+    <a href="/index.html#volumes">Browse Volumes</a>
+    <a href="#search">Search</a>
+  </nav>
+</header>
+<script src="/assets/js/layout.js" defer></script>

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html
@@ -1,65 +1,72 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Chapter 1 — The Beginning of Inquiry — SDIT</title>
-  <link rel="stylesheet" href="../../../../../assets/styles.css" />
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterSections(event) {
+      const query = event.target.value.toLowerCase();
+      document.querySelectorAll('.section-item').forEach(item => {
+        const text = item.innerText.toLowerCase();
+        item.style.display = text.includes(query) ? '' : 'none';
+      });
+    }
+  </script>
 </head>
 <body>
-  <header><h1>Chapter 1 — The Beginning of Inquiry</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="chapter-1-the-beginning-of-inquiry">Chapter 1 — The Beginning of Inquiry</h1>
-<hr />
-<h2 id="orientation">Orientation</h2>
-<p>Every education begins with a question. This chapter opens the door not to content, but to consciousness. You’ll explore five core modes of inquiry—liberal learning, storytelling, mathematical reasoning, scientific observation, and creative cognition—each a different lens for seeing the world and yourself within it.</p>
-<p>This isn’t about absorbing information. It’s about changing the way you pay attention. The goal is not mastery—it’s awakening. You’re beginning to build a personal archive of insight, to tune your perception, and to develop the tools to ask sharper questions.</p>
-<hr />
-<h2 id="intellectual-focus">Intellectual Focus</h2>
-<p>Chapter 1 asks:</p>
-<ul>
-<li>What is worth learning?</li>
-<li>What are the hidden patterns of thought and nature?</li>
-<li>How do stories, numbers, observations, and ideas reveal structure and meaning?</li>
-<li>How do I learn to think in a way that’s rigorous, imaginative, and alive?</li>
-</ul>
-<hr />
-<h2 id="chapter-sections">Chapter Sections</h2>
-<p>Each section is designed as a full-day learning experience—fluid, engaging, and self-paced. You are encouraged to read, watch, listen, make, and reflect with curiosity, not perfectionism.</p>
-<h3 id="section-01-lbs-101-what-is-a-liberal-education">Section 01 — LBS 101: <em>What is a Liberal Education?</em></h3>
-<p>Explore the philosophy of education and intellectual fitness.<br />
-<strong>File:</strong> <code>section-01.md</code></p>
-<h3 id="section-02-lbs-105-the-power-of-story">Section 02 — LBS 105: <em>The Power of Story</em></h3>
-<p>Analyze rhetoric and storytelling as persuasive and expressive tools.<br />
-<strong>File:</strong> <code>section-02.md</code></p>
-<h3 id="section-03-lbs-110-mathematics-as-a-language">Section 03 — LBS 110: <em>Mathematics as a Language</em></h3>
-<p>See numbers as patterns, relationships, and ways of knowing.<br />
-<strong>File:</strong> <code>section-03.md</code></p>
-<h3 id="section-04-lbs-120-observing-the-natural-world">Section 04 — LBS 120: <em>Observing the Natural World</em></h3>
-<p>Practice perception through motion, physics, and first-hand observation.<br />
-<strong>File:</strong> <code>section-04.md</code></p>
-<h3 id="section-05-lab-101-mapping-the-mind">Section 05 — LAB 101: <em>Mapping the Mind</em></h3>
-<p>Use mind-mapping and creative artifacts to observe your own thought.<br />
-<strong>File:</strong> <code>section-05.md</code></p>
-<hr />
-<h2 id="questions-to-carry-with-you">Questions to Carry With You</h2>
-<ul>
-<li>What does it mean to be “educated” in the 21st century?  </li>
-<li>How does story shape our beliefs—and whose stories get told?  </li>
-<li>What unseen patterns organize the world around me?  </li>
-<li>What happens when I observe without rushing to explain?  </li>
-<li>How can I begin to treat my own thoughts as material for creation?</li>
-</ul>
-<hr />
-<h2 id="meta-skill-curiosity-as-discipline">Meta Skill: Curiosity as Discipline</h2>
-<p>This chapter trains a foundational skill: disciplined curiosity.<br />
-Not blind exploration—but patterned, self-aware attention.<br />
-It’s the core habit of every scientist, artist, engineer, and original thinker.</p>
-<p>Your job in Chapter 1: learn how to ask better questions. Then follow them.</p>
+    <div class="breadcrumbs">
+      <a href="/index.html">Home</a>
+      <span class="sep">›</span>
+      <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Volume 1</a>
+      <span class="sep">›</span>
+      <strong>Chapter 1</strong>
+    </div>
+    <section class="hero">
+      <h2>Chapter 1: The Beginning of Inquiry</h2>
+      <p class="desc">Awaken disciplined curiosity across liberal learning, story, math, science, and creativity.</p>
+      <div class="search-bar"><input type="search" placeholder="Search sections" oninput="filterSections(event)" /></div>
+    </section>
+
+    <section>
+      <ul class="cards-grid">
+        <li class="section-item">
+          <a href="section-01.html">
+            <strong>Section 1 — What is a Liberal Education?</strong>
+            <div class="section-meta">Explore the philosophy of education and intellectual fitness.</div>
+          </a>
+        </li>
+        <li class="section-item">
+          <a href="section-02.html">
+            <strong>Section 2 — The Power of Story</strong>
+            <div class="section-meta">Analyze rhetoric and storytelling as persuasive and expressive tools.</div>
+          </a>
+        </li>
+        <li class="section-item">
+          <a href="section-03.html">
+            <strong>Section 3 — Mathematics as a Language</strong>
+            <div class="section-meta">See numbers as patterns, relationships, and ways of knowing.</div>
+          </a>
+        </li>
+        <li class="section-item">
+          <a href="section-04.html">
+            <strong>Section 4 — Observing the Natural World</strong>
+            <div class="section-meta">Practice perception through motion, physics, and first-hand observation.</div>
+          </a>
+        </li>
+        <li class="section-item">
+          <a href="section-05.html">
+            <strong>Section 5 — Mapping the Mind</strong>
+            <div class="section-meta">Use mind-mapping and creative artifacts to observe your own thought.</div>
+          </a>
+        </li>
+      </ul>
+    </section>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/section-01.html
@@ -5,11 +5,21 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Section 01 — What is a Liberal Education? (LBS 101) — SDIT</title>
-  <link rel="stylesheet" href="../../../../../assets/styles.css" />
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
 </head>
 <body>
-  <header><h1>Section 01 — What is a Liberal Education? (LBS 101)</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
+  <div class="breadcrumbs">
+    <a href="/index.html">Home</a>
+    <span class="sep">›</span>
+    <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Volume 1</a>
+    <span class="sep">›</span>
+    <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html">Chapter 1</a>
+    <span class="sep">›</span>
+    <strong>Section 1</strong>
+  </div>
   <h1 id="section-01-what-is-a-liberal-education">Section 01 — What is a Liberal Education?</h1>
 <p><strong>Course:</strong> LBS 101 – The Mental Gym</p>
 <hr />
@@ -103,8 +113,6 @@ Use drawings, arrows, symbols, or clusters. No need to be neat — be expressive
 <li>The goal is not to finish quickly — it’s to approah <em>truthfully</em>.  </li>
 </ul>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html
@@ -1,36 +1,60 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Volume 01 — Chapter Schedule Index — SDIT</title>
-  <link rel="stylesheet" href="../../../../assets/styles.css" />
+  <title>Volume 01 — Chapters — SDIT</title>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterChapters(event) {
+      const q = event.target.value.toLowerCase();
+      document.querySelectorAll('.chapter-card').forEach(card => {
+        const t = card.innerText.toLowerCase();
+        card.style.display = t.includes(q) ? '' : 'none';
+      });
+    }
+  </script>
 </head>
 <body>
-  <header><h1>Volume 01 — Chapter Schedule Index</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="chapter-schedule-index-volume-01">Chapter Schedule Index — Volume 01</h1>
-<ul>
-<li>Chapter 01: The Beginning of Inquiry — chapter-01/index.md</li>
-<li>Chapter 02 — chapter-02/index.md</li>
-<li>Chapter 03 — chapter-03/index.md</li>
-<li>Chapter 04 — chapter-04/index.md</li>
-<li>Chapter 05 — chapter-05/index.md</li>
-<li>Chapter 06 — chapter-06/index.md</li>
-<li>Chapter 07 — chapter-07/index.md</li>
-<li>Chapter 08 — chapter-08/index.md</li>
-<li>Chapter 09 — chapter-09/index.md</li>
-<li>Chapter 10 — chapter-10/index.md</li>
-<li>Chapter 11 — chapter-11/index.md</li>
-<li>Chapter 12 — chapter-12/index.md</li>
-<li>Chapter 13 — chapter-13/index.md</li>
-<li>Chapter 14 — chapter-14/index.md</li>
-<li>Chapter 15 — chapter-15/index.md</li>
-</ul>
+    <div class="breadcrumbs">
+      <a href="/index.html">Home</a>
+      <span class="sep">›</span>
+      <span>Volume 1</span>
+      <span class="sep">›</span>
+      <strong>Chapters</strong>
+    </div>
+    <section class="hero">
+      <h2>Volume 1: Foundations</h2>
+      <p class="desc">Explore the foundations of thinking, communication, math, science, and creativity.</p>
+      <div class="search-bar"><input type="search" id="search" placeholder="Search chapters" oninput="filterChapters(event)" /></div>
+    </section>
+
+    <section>
+      <div class="card-grid">
+        <div class="card chapter-card">
+          <h3><a href="chapter-01/index.html">Chapter 01: The Beginning of Inquiry</a></h3>
+          <p class="desc">Awaken disciplined curiosity across liberal learning, story, math, science, and creativity.</p>
+        </div>
+        <div class="card chapter-card"><h3><a href="chapter-02/index.html">Chapter 02</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-03/index.html">Chapter 03</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-04/index.html">Chapter 04</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-05/index.html">Chapter 05</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-06/index.html">Chapter 06</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-07/index.html">Chapter 07</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-08/index.html">Chapter 08</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-09/index.html">Chapter 09</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-10/index.html">Chapter 10</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-11/index.html">Chapter 11</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-12/index.html">Chapter 12</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-13/index.html">Chapter 13</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-14/index.html">Chapter 14</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card"><h3><a href="chapter-15/index.html">Chapter 15</a></h3><p class="desc">Overview coming soon.</p></div>
+      </div>
+    </section>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add reusable header/footer partials with metrics and layout scripts
- Style site with shared CSS and load partials via client-side includes
- Update home, volume 1 schedule, and chapter 1 pages with breadcrumbs, search, and card-based navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c701099924832e9550294122e6b629