### PR TITLE
style: add themed chapter cards and descriptions

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -49,6 +49,7 @@ main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
 .hero { text-align: center; margin-bottom: 40px; }
 .hero h2 { font-size: 32px; margin-bottom: 10px; }
 .hero p { font-size: 18px; color: var(--muted); margin-bottom: 20px; }
+.hero .icon { font-size: 40px; margin-bottom: 10px; }
 .cta-buttons { display: flex; justify-content: center; gap: 20px; flex-wrap: wrap; margin-bottom: 20px; }
 .btn { display: inline-block; padding: 10px 20px; background: var(--link); color: #fff; border-radius: 8px; text-decoration: none; font-weight: 500; }
 .btn:hover { opacity: 0.9; }
@@ -69,10 +70,13 @@ main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 10px;
-  padding: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 .card h3 { margin: 8px 0 6px; font-size: 18px; }
 .card .tagline, .card .desc { color: var(--muted); font-size: 14px; }
+.card .subtitle { font-size: 14px; color: var(--muted); margin: 0 0 8px; }
+.subtitle { font-size: 14px; color: var(--muted); margin: 0 0 8px; }
 .card .icon { font-size: 32px; }
 .card .card-actions { margin-top: 12px; display: flex; gap: 10px; }
 
@@ -90,7 +94,8 @@ main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 10px;
-  padding: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 .cards-grid .chapter-item a, .cards-grid .section-item a { color: var(--link); text-decoration: none; font-weight: 600; }
 .cards-grid .chapter-item a:hover, .cards-grid .section-item a:hover { text-decoration: underline; }

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-01/index.html
@@ -27,7 +27,9 @@
       <strong>Chapter 1</strong>
     </div>
     <section class="hero">
-      <h2>Chapter 1: The Beginning of Inquiry</h2>
+      <div class="icon">🔎</div>
+      <h2>The Beginning of Inquiry</h2>
+      <p class="subtitle">Chapter 01</p>
       <p class="desc">Awaken disciplined curiosity across liberal learning, story, math, science, and creativity.</p>
       <div class="search-bar"><input type="search" placeholder="Search sections" oninput="filterSections(event)" /></div>
     </section>

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-02/index.html
@@ -1,27 +1,50 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Chapter 2 — SDIT</title>
-  <link rel="stylesheet" href="../../../../../assets/styles.css" />
+  <title>Chapter 2 — The Power of Story — SDIT</title>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterSections(event) {
+      const query = event.target.value.toLowerCase();
+      document.querySelectorAll('.section-item').forEach(item => {
+        const text = item.innerText.toLowerCase();
+        item.style.display = text.includes(query) ? '' : 'none';
+      });
+    }
+  </script>
 </head>
 <body>
-  <header><h1>Chapter 2</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="chapter-2">Chapter 2</h1>
-<h2 id="this-chapters-five-courses">This Chapter’s Five Courses</h2>
-<ul>
-<li>Section 01 — LBS 101: Logic &amp; Reasoning — section-01.md</li>
-<li>Section 02 — LBS 105: Voice &amp; Style — section-02.md</li>
-<li>Section 03 — LBS 110: Patterns &amp; Sequences — section-03.md</li>
-<li>Section 04 — LBS 120: Motion &amp; Measurement — section-04.md</li>
-<li>Section 05 — LAB 101: Creative Constraints — section-05.md</li>
-</ul>
+    <div class="breadcrumbs">
+      <a href="/index.html">Home</a>
+      <span class="sep">›</span>
+      <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Volume 1</a>
+      <span class="sep">›</span>
+      <strong>Chapter 2</strong>
+    </div>
+    <section class="hero">
+      <div class="icon">📖</div>
+      <h2>The Power of Story</h2>
+      <p class="subtitle">Chapter 02</p>
+      <p class="desc">Discover how narrative shapes memory, identity, and meaning across cultures.</p>
+      <div class="search-bar"><input type="search" placeholder="Search sections" oninput="filterSections(event)" /></div>
+    </section>
+
+    <section>
+      <ul class="cards-grid">
+        <li class="section-item"><a href="section-01.html">Section 01 — LBS 101: Logic &amp; Reasoning</a></li>
+        <li class="section-item"><a href="section-02.html">Section 02 — LBS 105: Voice &amp; Style</a></li>
+        <li class="section-item"><a href="section-03.html">Section 03 — LBS 110: Patterns &amp; Sequences</a></li>
+        <li class="section-item"><a href="section-04.html">Section 04 — LBS 120: Motion &amp; Measurement</a></li>
+        <li class="section-item"><a href="section-05.html">Section 05 — LAB 101: Creative Constraints</a></li>
+      </ul>
+    </section>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>
+

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-03/index.html
@@ -1,27 +1,50 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Chapter 3 — SDIT</title>
-  <link rel="stylesheet" href="../../../../../assets/styles.css" />
+  <title>Chapter 3 — Mathematics as Language — SDIT</title>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterSections(event) {
+      const query = event.target.value.toLowerCase();
+      document.querySelectorAll('.section-item').forEach(item => {
+        const text = item.innerText.toLowerCase();
+        item.style.display = text.includes(query) ? '' : 'none';
+      });
+    }
+  </script>
 </head>
 <body>
-  <header><h1>Chapter 3</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="chapter-3">Chapter 3</h1>
-<h2 id="this-chapters-five-courses">This Chapter’s Five Courses</h2>
-<ul>
-<li>Section 01 — LBS 101: The Examined Life — section-01.md</li>
-<li>Section 02 — LBS 105: Argument &amp; Persuasion — section-02.md</li>
-<li>Section 03 — LBS 110: Ratios &amp; Proportions — section-03.md</li>
-<li>Section 04 — LBS 120: Forces &amp; Balance — section-04.md</li>
-<li>Section 05 — LAB 101: Play as Learning — section-05.md</li>
-</ul>
+    <div class="breadcrumbs">
+      <a href="/index.html">Home</a>
+      <span class="sep">›</span>
+      <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Volume 1</a>
+      <span class="sep">›</span>
+      <strong>Chapter 3</strong>
+    </div>
+    <section class="hero">
+      <div class="icon">🔢</div>
+      <h2>Mathematics as Language</h2>
+      <p class="subtitle">Chapter 03</p>
+      <p class="desc">See math not just as numbers, but as a universal code of patterns and ideas.</p>
+      <div class="search-bar"><input type="search" placeholder="Search sections" oninput="filterSections(event)" /></div>
+    </section>
+
+    <section>
+      <ul class="cards-grid">
+        <li class="section-item"><a href="section-01.html">Section 01 — LBS 101: The Examined Life</a></li>
+        <li class="section-item"><a href="section-02.html">Section 02 — LBS 105: Argument &amp; Persuasion</a></li>
+        <li class="section-item"><a href="section-03.html">Section 03 — LBS 110: Ratios &amp; Proportions</a></li>
+        <li class="section-item"><a href="section-04.html">Section 04 — LBS 120: Forces &amp; Balance</a></li>
+        <li class="section-item"><a href="section-05.html">Section 05 — LAB 101: Play as Learning</a></li>
+      </ul>
+    </section>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>
+

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-04/index.html
@@ -1,27 +1,50 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Chapter 4 — SDIT</title>
-  <link rel="stylesheet" href="../../../../../assets/styles.css" />
+  <title>Chapter 4 — Observing the Natural World — SDIT</title>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterSections(event) {
+      const query = event.target.value.toLowerCase();
+      document.querySelectorAll('.section-item').forEach(item => {
+        const text = item.innerText.toLowerCase();
+        item.style.display = text.includes(query) ? '' : 'none';
+      });
+    }
+  </script>
 </head>
 <body>
-  <header><h1>Chapter 4</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="chapter-4">Chapter 4</h1>
-<h2 id="this-chapters-five-courses">This Chapter’s Five Courses</h2>
-<ul>
-<li>Section 01 — LBS 101: Truth &amp; Perspectives — section-01.md</li>
-<li>Section 02 — LBS 105: Structure &amp; Flow — section-02.md</li>
-<li>Section 03 — LBS 110: Infinity &amp; Limits — section-03.md</li>
-<li>Section 04 — LBS 120: Energy &amp; Work — section-04.md</li>
-<li>Section 05 — LAB 101: Storytelling Through Images — section-05.md</li>
-</ul>
+    <div class="breadcrumbs">
+      <a href="/index.html">Home</a>
+      <span class="sep">›</span>
+      <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Volume 1</a>
+      <span class="sep">›</span>
+      <strong>Chapter 4</strong>
+    </div>
+    <section class="hero">
+      <div class="icon">🌿</div>
+      <h2>Observing the Natural World</h2>
+      <p class="subtitle">Chapter 04</p>
+      <p class="desc">Learn to observe, describe, and question the living systems around us.</p>
+      <div class="search-bar"><input type="search" placeholder="Search sections" oninput="filterSections(event)" /></div>
+    </section>
+
+    <section>
+      <ul class="cards-grid">
+        <li class="section-item"><a href="section-01.html">Section 01 — LBS 101: Inquiry &amp; Evidence</a></li>
+        <li class="section-item"><a href="section-02.html">Section 02 — LBS 105: Visual Thinking</a></li>
+        <li class="section-item"><a href="section-03.html">Section 03 — LBS 110: Geometry &amp; Space</a></li>
+        <li class="section-item"><a href="section-04.html">Section 04 — LBS 120: Energy &amp; Work</a></li>
+        <li class="section-item"><a href="section-05.html">Section 05 — LAB 101: Storytelling Through Images</a></li>
+      </ul>
+    </section>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>
+

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/chapter-05/index.html
@@ -1,27 +1,50 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Chapter 5 — SDIT</title>
-  <link rel="stylesheet" href="../../../../../assets/styles.css" />
+  <title>Chapter 5 — Mapping the Mind — SDIT</title>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterSections(event) {
+      const query = event.target.value.toLowerCase();
+      document.querySelectorAll('.section-item').forEach(item => {
+        const text = item.innerText.toLowerCase();
+        item.style.display = text.includes(query) ? '' : 'none';
+      });
+    }
+  </script>
 </head>
 <body>
-  <header><h1>Chapter 5</h1></header>
+  <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="chapter-5">Chapter 5</h1>
-<h2 id="this-chapters-five-courses">This Chapter’s Five Courses</h2>
-<ul>
-<li>Section 01 — LBS 101: Rhetoric &amp; Persuasion — section-01.md</li>
-<li>Section 02 — LBS 105: Audience Awareness — section-02.md</li>
-<li>Section 03 — LBS 110: Probability &amp; Uncertainty — section-03.md</li>
-<li>Section 04 — LBS 120: Sound &amp; Vibration — section-04.md</li>
-<li>Section 05 — LAB 101: Improvisation &amp; Surprise — section-05.md</li>
-</ul>
+    <div class="breadcrumbs">
+      <a href="/index.html">Home</a>
+      <span class="sep">›</span>
+      <a href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">Volume 1</a>
+      <span class="sep">›</span>
+      <strong>Chapter 5</strong>
+    </div>
+    <section class="hero">
+      <div class="icon">🧠</div>
+      <h2>Mapping the Mind</h2>
+      <p class="subtitle">Chapter 05</p>
+      <p class="desc">Explore how humans think, remember, and create meaning from experience.</p>
+      <div class="search-bar"><input type="search" placeholder="Search sections" oninput="filterSections(event)" /></div>
+    </section>
+
+    <section>
+      <ul class="cards-grid">
+        <li class="section-item"><a href="section-01.html">Section 01 — LBS 101: Narrative &amp; Identity</a></li>
+        <li class="section-item"><a href="section-02.html">Section 02 — LBS 105: Research &amp; Reporting</a></li>
+        <li class="section-item"><a href="section-03.html">Section 03 — LBS 110: Data &amp; Information</a></li>
+        <li class="section-item"><a href="section-04.html">Section 04 — LBS 120: Sound &amp; Vibration</a></li>
+        <li class="section-item"><a href="section-05.html">Section 05 — LAB 101: Improvisation &amp; Surprise</a></li>
+      </ul>
+    </section>
   </main>
-  <footer>
-    <p>Built locally from repo content.</p>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>
+

--- a/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html
+++ b/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html
@@ -27,7 +27,9 @@
       <strong>Chapters</strong>
     </div>
     <section class="hero">
+      <div class="icon">📚</div>
       <h2>Volume 1: Foundations</h2>
+      <p class="subtitle">Volume 1 of 5</p>
       <p class="desc">Explore the foundations of thinking, communication, math, science, and creativity.</p>
       <div class="search-bar"><input type="search" id="search" placeholder="Search chapters" oninput="filterChapters(event)" /></div>
     </section>
@@ -35,23 +37,90 @@
     <section>
       <div class="card-grid">
         <div class="card chapter-card">
-          <h3><a href="chapter-01/index.html">Chapter 01: The Beginning of Inquiry</a></h3>
+          <div class="icon">🔎</div>
+          <h3>The Beginning of Inquiry</h3>
+          <p class="subtitle">Chapter 01</p>
           <p class="desc">Awaken disciplined curiosity across liberal learning, story, math, science, and creativity.</p>
+          <a class="btn" href="chapter-01/index.html">View Chapter</a>
         </div>
-        <div class="card chapter-card"><h3><a href="chapter-02/index.html">Chapter 02</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-03/index.html">Chapter 03</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-04/index.html">Chapter 04</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-05/index.html">Chapter 05</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-06/index.html">Chapter 06</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-07/index.html">Chapter 07</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-08/index.html">Chapter 08</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-09/index.html">Chapter 09</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-10/index.html">Chapter 10</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-11/index.html">Chapter 11</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-12/index.html">Chapter 12</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-13/index.html">Chapter 13</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-14/index.html">Chapter 14</a></h3><p class="desc">Overview coming soon.</p></div>
-        <div class="card chapter-card"><h3><a href="chapter-15/index.html">Chapter 15</a></h3><p class="desc">Overview coming soon.</p></div>
+        <div class="card chapter-card">
+          <div class="icon">📖</div>
+          <h3>The Power of Story</h3>
+          <p class="subtitle">Chapter 02</p>
+          <p class="desc">Discover how narrative shapes memory, identity, and meaning across cultures.</p>
+          <a class="btn" href="chapter-02/index.html">View Chapter</a>
+        </div>
+        <div class="card chapter-card">
+          <div class="icon">🔢</div>
+          <h3>Mathematics as Language</h3>
+          <p class="subtitle">Chapter 03</p>
+          <p class="desc">See math not just as numbers, but as a universal code of patterns and ideas.</p>
+          <a class="btn" href="chapter-03/index.html">View Chapter</a>
+        </div>
+        <div class="card chapter-card">
+          <div class="icon">🌿</div>
+          <h3>Observing the Natural World</h3>
+          <p class="subtitle">Chapter 04</p>
+          <p class="desc">Learn to observe, describe, and question the living systems around us.</p>
+          <a class="btn" href="chapter-04/index.html">View Chapter</a>
+        </div>
+        <div class="card chapter-card">
+          <div class="icon">🧠</div>
+          <h3>Mapping the Mind</h3>
+          <p class="subtitle">Chapter 05</p>
+          <p class="desc">Explore how humans think, remember, and create meaning from experience.</p>
+          <a class="btn" href="chapter-05/index.html">View Chapter</a>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 06</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 07</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 08</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 09</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 10</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 11</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 12</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 13</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 14</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
+        <div class="card chapter-card">
+          <h3>Coming Soon</h3>
+          <p class="subtitle">Chapter 15</p>
+          <p class="desc">Explore upcoming themes in this chapter.</p>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- style chapter cards with icons, subtitles, and short hooks
- add Volume 1 progress cue and polished typography
- refresh chapters 1-5 with theme-first titles and section grids

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c706e287b8832ebe22b547ab57536b