### PR TITLE
Use feather icons on home and center cards

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -90,7 +90,14 @@ main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
 /* Volume cards (home) */
 .volume-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
 .volume-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 20px; text-align: center; }
-.volume-card .icon { font-size: 36px; margin-bottom: 10px; }
+.volume-card .icon {
+  margin-bottom: 10px;
+  color: var(--link);
+}
+.volume-card .icon svg {
+  width: 36px;
+  height: 36px;
+}
 .volume-card h3 { margin: 10px 0; font-size: 20px; }
 .volume-card .tagline { color: var(--muted); font-size: 15px; margin-bottom: 20px; }
 
@@ -107,6 +114,13 @@ main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
 .cards-grid .chapter-item a, .cards-grid .section-item a { color: var(--link); text-decoration: none; font-weight: 600; }
 .cards-grid .chapter-item a:hover, .cards-grid .section-item a:hover { text-decoration: underline; }
 .cards-grid .section-meta { color: var(--muted); font-size: 14px; margin-top: 6px; }
+
+/* Center chapter and section cards */
+.card.chapter-card,
+.cards-grid .chapter-item,
+.cards-grid .section-item {
+  text-align: center;
+}
 
 @media (max-width: 768px) {
   main { padding: 20px 16px; }

--- a/index.html
+++ b/index.html
@@ -33,49 +33,49 @@
     </div>
     <section id="volumes" class="volume-grid">
       <div class="volume-card">
-        <div class="icon">📚</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a4 4 0 0 0-4-4H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a4 4 0 0 1 4-4h6z"></path></svg></div>
         <h3>Volume 1: Foundations</h3>
         <p class="tagline">Groundwork in thinking, communication, math, science, and creativity.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">⚖️</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line></svg></div>
         <h3>Volume 2: Ethics &amp; Reasoning</h3>
         <p class="tagline">Explore moral philosophy and sharpen logical reasoning.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">🗣️</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg></div>
         <h3>Volume 3: Communication Rhetoric</h3>
         <p class="tagline">Develop effective communication and persuasive skills.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">🔬</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg></div>
         <h3>Volume 4: Science Systems</h3>
         <p class="tagline">Investigate scientific principles and complex systems.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">🎨</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg></div>
         <h3>Volume 5: Design Creativity</h3>
         <p class="tagline">Practice design thinking to unlock creativity.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">📈</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg></div>
         <h3>Volume 6: Economy History</h3>
         <p class="tagline">Trace economic ideas through historical contexts.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">💻</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09A1.65 1.65 0 0 0 9 3.09V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg></div>
         <h3>Volume 7: Technology Society</h3>
         <p class="tagline">Examine technology's role in shaping society.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html">View Chapters</a>
       </div>
       <div class="volume-card">
-        <div class="icon">🌟</div>
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><line x1="12" y1="2" x2="12" y2="22"></line><path d="M4.93 4.93a10.94 10.94 0 0 0 0 14.14"></path><path d="M19.07 4.93a10.94 10.94 0 0 1 0 14.14"></path></svg></div>
         <h3>Volume 8: Leadership Citizenship</h3>
         <p class="tagline">Build leadership skills and civic responsibility.</p>
         <a class="btn" href="/programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html">View Chapters</a>


### PR DESCRIPTION
## Summary
- Replace home page volume emojis with Feather-style SVG icons.
- Add colorized, scalable icon styling for volume cards and center chapter/section card layouts.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c73f3ddbc8832e820887c196b2bc1b