### PR TITLE
Unify chapter and section styling with home page layout

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,37 +1,24 @@
+/* Legacy stylesheet now forwards to site.css for consistent layout.
+   Ensures chapters and sections use the same centered, clean formatting
+   as the home page. */
+@import url('/assets/site.css');
 
-    :root {
-      --bg: #0b0d12; --card:#13161d; --elev:#1a1f27; --fg:#e8eaee; --muted:#a2a7b0; --link:#7cc4ff; --accent:#2a9d8f;
-    }
-    * { box-sizing: border-box; }
-    html { font-size: 16px; }
-    body {
-      margin: 0; font-family: Inter, -apple-system, Segoe UI, Roboto, system-ui, sans-serif;
-      color: var(--fg); background: radial-gradient(1200px 600px at 10% -10%, #10141b 0%, var(--bg) 50%);
-      line-height: 1.7;
-    }
-    header { padding: 24px 20px; border-bottom: 1px solid #1f2430; background: linear-gradient(180deg, #0f1320 0%, rgba(0,0,0,0) 100%); }
-    header h1 { margin: 0 0 6px; font-size: 22px; letter-spacing: .3px; }
-    main { padding: 22px; max-width: 1040px; margin: 0 auto; }
-    section { background: var(--card); padding: 14px 16px; margin: 12px 0; border-radius: 10px; border: 1px solid #1f2430; }
-    /* Collapsible tree (details/summary) */
-    details { background: var(--card); border-radius: 10px; padding: 8px 12px; margin: 10px 0; border: 1px solid #1f2430; }
-    details[open] { padding-bottom: 10px; }
-    details > summary { cursor: pointer; list-style: none; font-weight: 600; display: flex; align-items: center; gap: 6px; }
-    details > summary::-webkit-details-marker { display: none; }
-    details > summary::marker { content: ""; }
-    details > summary::before { content: "▸"; display: inline-block; width: 1em; color: var(--muted); transition: transform .15s ease; }
-    details[open] > summary::before { content: "▾"; }
-    details ul { margin: 6px 0 0 18px; padding-left: 10px; }
-    li { margin: 3px 0; }
-    ul { padding-left: 20px; }
-    a { color: var(--link); text-decoration: none; }
-    a:hover { text-decoration: underline; }
-    h1, h2, h3 { color: #fff; }
-    code, pre { background: #0f1219; border-radius: 8px; border: 1px solid #1f2430; }
-    pre { padding: 12px; overflow: auto; }
-    dl { display: grid; grid-template-columns: max-content 1fr; gap: 6px 12px; }
-    dt { color: #c9cfd8; }
-    dd { margin: 0 0 6px 0; }
-    .desc { color: var(--muted); }
-    footer { padding: 20px; color: var(--muted); border-top: 1px solid #1f2430; margin-top: 28px; }
-    
+/* Basic header/footer styling for pages without site-header/footer classes */
+header {
+  text-align: center;
+  padding: 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--highlight);
+}
+header h1 {
+  margin: 0;
+}
+footer {
+  margin-top: 60px;
+  text-align: center;
+  padding: 30px;
+  font-size: 14px;
+  color: var(--muted);
+  background: var(--highlight);
+  border-top: 1px solid var(--border);
+}


### PR DESCRIPTION
## Summary
- Redirect legacy `styles.css` to import modern `site.css`
- Add centered header and footer styles for chapter and section pages

## Testing
- `python scripts/validate.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68c741e7336c832e8cdf27e8cb289fdf