### PR TITLE
Add curriculum overview page for Bachelor program

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -98,8 +98,11 @@ main { padding: 40px 20px; max-width: 1100px; margin: 0 auto; }
   width: 36px;
   height: 36px;
 }
-.volume-card h3 { margin: 10px 0; font-size: 20px; }
-.volume-card .tagline { color: var(--muted); font-size: 15px; margin-bottom: 20px; }
+.volume-card h3 { margin: 10px 0; font-size: 22px; font-weight: 700; }
+.volume-card .tagline { color: var(--muted); font-size: 15px; margin: 0 0 8px; }
+.volume-card .meta { color: var(--muted); font-size: 14px; margin-bottom: 12px; }
+.volume-card .view-link { color: var(--link); text-decoration: none; font-weight: 500; }
+.volume-card .view-link:hover { text-decoration: underline; }
 
 /* Chapters and Sections as cards */
 .cards-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; }

--- a/programs/Bachelor-Liberal-Arts/index.html
+++ b/programs/Bachelor-Liberal-Arts/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bachelor of Liberal Arts — Curriculum Overview</title>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/js/includes.js" defer></script>
+  <script>
+    function filterCards(event) {
+      const query = event.target.value.toLowerCase();
+      document.querySelectorAll('.volume-card').forEach(card => {
+        const text = card.innerText.toLowerCase();
+        card.style.display = text.includes(query) ? '' : 'none';
+      });
+    }
+  </script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+  <main>
+    <h2>Curriculum Overview</h2>
+    <div class="search-bar" id="search">
+      <input type="search" placeholder="Search volumes" oninput="filterCards(event)" />
+    </div>
+    <section class="volume-grid">
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a4 4 0 0 0-4-4H2z"></path><path d="M2 3h-6a4 4 0 0 0-4 4v14a4 4 0 0 1 4-4h6z"></path></svg></div>
+        <h3>1. Foundations</h3>
+        <p class="tagline">Core skills in math, science, and critical thinking.</p>
+        <p class="meta">15 chapters</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line></svg></div>
+        <h3>2. Ethics &amp; Reasoning</h3>
+        <p class="tagline">Explore philosophy and sharpen your arguments.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-02-ethics-and-reasoning/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg></div>
+        <h3>3. Communication</h3>
+        <p class="tagline">Writing, speaking, and persuasion for impact.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-03-communication-rhetoric/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg></div>
+        <h3>4. Science &amp; Systems</h3>
+        <p class="tagline">Investigate scientific principles and complex systems.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-04-science-systems/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg></div>
+        <h3>5. Design &amp; Creativity</h3>
+        <p class="tagline">Practice design thinking to unlock creativity.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-05-design-creativity/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg></div>
+        <h3>6. Economy &amp; History</h3>
+        <p class="tagline">Trace economic ideas through historical contexts.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-06-economy-history/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09A1.65 1.65 0 0 0 9 3.09V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg></div>
+        <h3>7. Technology &amp; Society</h3>
+        <p class="tagline">Examine technology's role in shaping society.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-07-technology-society/syllabus.html">View Chapters</a>
+      </div>
+      <div class="volume-card">
+        <div class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><line x1="12" y1="2" x2="12" y2="22"></line><path d="M4.93 4.93a10.94 10.94 0 0 0 0 14.14"></path><path d="M19.07 4.93a10.94 10.94 0 0 1 0 14.14"></path></svg></div>
+        <h3>8. Leadership &amp; Citizenship</h3>
+        <p class="tagline">Build leadership skills and civic responsibility.</p>
+        <p class="meta">Chapters coming soon</p>
+        <a class="view-link" href="/programs/Bachelor-Liberal-Arts/vol-08-leadership-citizenship/syllabus.html">View Chapters</a>
+      </div>
+    </section>
+  </main>
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add card-based curriculum overview for the Bachelor of Liberal Arts program
- Refine volume card styles for clearer hierarchy and subtle link hover

## Testing
- `python scripts/validate.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68c743a7c924832e9a5520cb622dfbb4