### PR TITLE
Uniform semester-1 course pages, data-driven schedule, dead-code strip

### DIFF
--- a/assets/js/layout.js
+++ b/assets/js/layout.js
@@ -1,3 +1,12 @@
+/**
+ * layout.js — page chrome for the SDIT curriculum site.
+ *
+ * - Highlights the active masthead nav item.
+ * - Course day pages (/courses/CODE/day-NN.html): wraps content in the
+ *   lesson shell (topbar, day rail, sectioned content, resource cards).
+ * - Course overview pages (/courses/CODE/): code badge eyebrow and
+ *   sectioned content cards.
+ */
 (function () {
   if (window.__sditLayoutReady) {
     return;
@@ -10,68 +19,6 @@
     }
     return path;
   }
-
-  const volumeMeta = {
-    "vol-01-foundations": {
-      title: "Foundations",
-      label: "Volume 1",
-      year: "Year 1",
-      term: "Term 1",
-      chapters: 15,
-      daysPerChapter: 5,
-      schedulePath: "/programs/Bachelor-Liberal-Arts/vol-01-foundations/schedule/index.html",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-02-ethics-and-reasoning": {
-      title: "Ethics and Reasoning",
-      label: "Volume 2",
-      year: "Year 1",
-      term: "Term 2",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-03-communication-rhetoric": {
-      title: "Communication and Rhetoric",
-      label: "Volume 3",
-      year: "Year 2",
-      term: "Term 1",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-04-science-systems": {
-      title: "Science and Systems",
-      label: "Volume 4",
-      year: "Year 2",
-      term: "Term 2",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-05-design-creativity": {
-      title: "Design and Creativity",
-      label: "Volume 5",
-      year: "Year 3",
-      term: "Term 1",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-06-economy-history": {
-      title: "Economy and History",
-      label: "Volume 6",
-      year: "Year 3",
-      term: "Term 2",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-07-technology-society": {
-      title: "Technology and Society",
-      label: "Volume 7",
-      year: "Year 4",
-      term: "Term 1",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    },
-    "vol-08-leadership-citizenship": {
-      title: "Leadership and Citizenship",
-      label: "Volume 8",
-      year: "Year 4",
-      term: "Term 2",
-      programPath: "/programs/Bachelor-Liberal-Arts/index.html"
-    }
-  };
 
   function pad(value) {
     return String(value).padStart(2, "0");
@@ -104,65 +51,10 @@
     return path === "/" ? "/index.html" : path;
   }
 
-  function getVolumeSlug(pathname) {
-    const match = pathname.match(/\/(vol-\d{2}-[^/]+)/);
-    return match ? match[1] : null;
-  }
-
-  function getChapterNumber(pathname) {
-    const match = pathname.match(/\/chapter-(\d{2})\//);
-    return match ? Number(match[1]) : null;
-  }
-
-  function getDayNumber(pathname) {
-    const match = pathname.match(/\/section-(\d{2})\.html$/);
-    return match ? Number(match[1]) : null;
-  }
-
-  function getVolumeData(pathname) {
-    const slug = getVolumeSlug(pathname);
-    return slug ? volumeMeta[slug] || null : null;
-  }
-
-  function wrapAsGrid(items) {
-    if (!items.length) {
-      return;
-    }
-
-    const first = items[0];
-    const parent = first.parentElement;
-    if (!parent || parent.classList.contains("cards-grid")) {
-      return;
-    }
-
-    const grid = document.createElement("div");
-    grid.className = "cards-grid";
-    parent.insertBefore(grid, first);
-
-    const directChildren = Array.from(parent.children).filter(function (child) {
-      return child.classList.contains("chapter-item") || child.classList.contains("section-item");
-    });
-
-    directChildren.forEach(function (child) {
-      grid.appendChild(child);
-    });
-  }
-
-  function enhanceCardGrids() {
-    const chapterItems = Array.from(document.querySelectorAll(".chapter-item"));
-    const sectionItems = Array.from(document.querySelectorAll(".section-item"));
-
-    if (chapterItems.length) {
-      wrapAsGrid(chapterItems);
-    }
-
-    if (sectionItems.length) {
-      wrapAsGrid(sectionItems);
-    }
-  }
+  /* ── Masthead nav ─────────────────────────────────────────── */
 
   function updateActiveNav() {
-    const navLinks = document.querySelectorAll(".learn-nav a[data-nav], .masthead .toc a[data-nav], .site-nav a[data-nav]");
+    const navLinks = document.querySelectorAll(".masthead .toc a[data-nav]");
     if (!navLinks.length) {
       return;
     }
@@ -190,411 +82,8 @@
     });
   }
 
-  function bindMobileNav() {
-    const header = document.querySelector(".site-header");
-    const toggle = document.querySelector(".site-nav-toggle");
-    const nav = document.querySelector(".site-nav");
+  /* ── Lesson section map ───────────────────────────────────── */
 
-    if (!header || !toggle || !nav || toggle.dataset.bound === "true") {
-      return;
-    }
-
-    function closeNav() {
-      header.classList.remove("is-nav-open");
-      toggle.setAttribute("aria-expanded", "false");
-    }
-
-    function syncNavForViewport() {
-      if (window.innerWidth > 760) {
-        closeNav();
-      }
-    }
-
-    toggle.addEventListener("click", function () {
-      const isOpen = header.classList.toggle("is-nav-open");
-      toggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
-    });
-
-    nav.querySelectorAll("a").forEach(function (link) {
-      link.addEventListener("click", function () {
-        closeNav();
-      });
-    });
-
-    window.addEventListener("resize", syncNavForViewport);
-    syncNavForViewport();
-    toggle.dataset.bound = "true";
-  }
-
-  function enhanceSectionCards() {
-    document.querySelectorAll(".section-item").forEach(function (item, index) {
-      const link = item.querySelector("a") || item;
-      const strong = link.querySelector("strong");
-      const sectionMeta = link.querySelector(".section-meta");
-      const rawText = (strong ? strong.textContent : link.textContent || "").trim();
-      const dayMatch = rawText.match(/Section\s+(\d+)/i);
-      const dayValue = dayMatch ? pad(dayMatch[1]) : pad(index + 1);
-
-      if (!link.querySelector(".day-badge")) {
-        link.insertBefore(createElement("span", "day-badge", "Day " + dayValue), link.firstChild);
-      }
-
-      if (strong) {
-        strong.classList.add("section-item__title");
-        strong.textContent = strong.textContent.replace(/^Section/i, "Day");
-      } else if (!link.querySelector(".section-item__title")) {
-        const title = createElement("span", "section-item__title");
-        title.textContent = rawText
-          .replace(/\s+[-\u2014]\s+section-\d+\.md$/i, "")
-          .replace(/^Section/i, "Day");
-        link.textContent = "";
-        link.appendChild(createElement("span", "day-badge", "Day " + dayValue));
-        link.appendChild(title);
-      }
-
-      if (sectionMeta) {
-        sectionMeta.classList.add("section-meta");
-      }
-
-      if (!link.querySelector(".section-arrow")) {
-        link.appendChild(createElement("span", "section-arrow", "Open lesson"));
-      }
-    });
-  }
-
-  function enhanceChapterPage() {
-    var path = currentPath();
-    if (!/\/chapter-\d{2}\/index\.html$/.test(path)) return;
-
-    document.body.classList.add("chapter-page");
-
-    var chapterNumber = getChapterNumber(path);
-    var volumeSlug = getVolumeSlug(path);
-    var volume = getVolumeData(path);
-    if (!chapterNumber || !volume) return;
-
-    var main = document.querySelector("main");
-    if (!main) return;
-
-    // Extract chapter title from H1 ("Chapter 2 — Title" → "Title")
-    var h1 = main.querySelector("h1");
-    var chapterTitle = "";
-    if (h1) {
-      var rawTitle = h1.textContent || "";
-      var titleM = rawTitle.match(/^Chapter\s+\d+\s*[\u2014\-]\s*(.+)$/i);
-      chapterTitle = titleM ? titleM[1].trim() : rawTitle.replace(/^Chapter\s+\d+\s*/i, "").trim();
-    }
-    if (!chapterTitle) chapterTitle = "Week " + chapterNumber;
-
-    // Extract orientation from first <p>
-    var orientationText = "";
-    var firstPara = main.querySelector("p");
-    if (firstPara) orientationText = firstPara.textContent.trim();
-
-    // Parse day list items: "Day 01 — LBS 101: Title" or "Section 01 — LBS 101: Title"
-    var DAY_RE = /^(?:Day|Section)\s+0*(\d+)\s*[\u2014\-]\s*([A-Z]+\s+\d+)\s*:\s*(.+?)(?:\s*[\u2014\-]\s*section-\d+\.md)?$/i;
-    var days = [];
-    Array.from(main.querySelectorAll("li")).forEach(function(li) {
-      var text = (li.textContent || "").trim();
-      var m = text.match(DAY_RE);
-      if (m) {
-        days.push({ num: parseInt(m[1], 10), course: m[2].trim(), title: m[3].trim() });
-      }
-    });
-    // Also parse H3 elements ("### Section 01 — LBS 101: Title")
-    if (!days.length) {
-      Array.from(main.querySelectorAll("h3")).forEach(function(h3) {
-        var text = (h3.textContent || "").trim();
-        var m = text.match(DAY_RE);
-        if (m) {
-          days.push({ num: parseInt(m[1], 10), course: m[2].trim(), title: m[3].trim() });
-        }
-      });
-    }
-    if (!days.length) {
-      for (var i = 1; i <= 5; i++) {
-        days.push({ num: i, course: "", title: "Day " + i });
-      }
-    }
-
-    var basePath = "/programs/Bachelor-Liberal-Arts/" + volumeSlug + "/schedule/";
-
-    // Eyebrow
-    var eyebrow = createElement("div", "chapter-eyebrow");
-    eyebrow.appendChild(createElement("span", "chapter-vol-label",
-      volume.label + " \u00b7 " + volume.year + " \u00b7 " + volume.term));
-    eyebrow.appendChild(createElement("span", "chapter-week-label",
-      "Week " + chapterNumber + " of " + volume.chapters));
-
-    // Hero
-    var hero = createElement("div", "chapter-hero");
-    hero.appendChild(eyebrow);
-    var heroH1 = document.createElement("h1");
-    heroH1.className = "chapter-title";
-    var weekSpan = createElement("span", "chapter-week-num", "Week " + chapterNumber);
-    heroH1.appendChild(weekSpan);
-    heroH1.appendChild(document.createTextNode(" \u2014 " + chapterTitle));
-    hero.appendChild(heroH1);
-
-    if (orientationText) {
-      hero.appendChild(createElement("p", "chapter-intro", orientationText));
-    }
-
-    var stats = createElement("div", "chapter-stats");
-    [
-      { v: "5", l: "days" },
-      { v: "5", l: "courses" },
-      { v: volume.year, l: volume.term }
-    ].forEach(function(s) {
-      var stat = createElement("div", "chapter-stat");
-      stat.appendChild(createElement("strong", "", s.v));
-      stat.appendChild(createElement("span", "", s.l));
-      stats.appendChild(stat);
-    });
-    hero.appendChild(stats);
-
-    // Day grid
-    var grid = createElement("div", "chapter-day-grid");
-    days.forEach(function(day) {
-      // Resolve course URL — prefer /courses/COURSE-ID/day-NN.html with program context
-      var courseId = day.course ? day.course.replace(/\s+/, "-").toUpperCase() : null;
-      var href;
-      if (courseId && COURSE_DIRS[courseId]) {
-        href = resolveSitePath(
-          "/courses/" + courseId + "/day-" + pad(day.num) + ".html" +
-          "?prog=bla&vol=" + volumeSlug + "&week=" + chapterNumber + "&pos=" + day.num
-        );
-      } else {
-        // Fall back to old section URL for courses not yet migrated
-        href = resolveSitePath(
-          basePath + "chapter-" + pad(chapterNumber) + "/section-" + pad(day.num) + ".html"
-        );
-      }
-      var card = document.createElement("a");
-      card.className = "chapter-day-card";
-      card.href = href;
-      card.appendChild(createElement("span", "chapter-day-num", "Day " + pad(day.num)));
-      card.appendChild(createElement("span", "chapter-day-title", day.title));
-      if (day.course) {
-        card.appendChild(createElement("span", "chapter-day-course", day.course));
-      }
-      card.appendChild(createElement("span", "chapter-day-arrow", "\u2192"));
-      grid.appendChild(card);
-    });
-
-    // Nav
-    var nav = createElement("div", "chapter-nav");
-    if (chapterNumber > 1) {
-      var prev = createElement("a", "chapter-nav-prev",
-        "\u2190 Week " + (chapterNumber - 1));
-      prev.href = resolveSitePath(basePath + "chapter-" + pad(chapterNumber - 1) + "/index.html");
-      nav.appendChild(prev);
-    }
-    var sched = createElement("a", "chapter-nav-schedule", "\u2630 Full Schedule");
-    sched.href = resolveSitePath(basePath + "index.html");
-    nav.appendChild(sched);
-    if (chapterNumber < volume.chapters) {
-      var next = createElement("a", "chapter-nav-next",
-        "Week " + (chapterNumber + 1) + " \u2192");
-      next.href = resolveSitePath(basePath + "chapter-" + pad(chapterNumber + 1) + "/index.html");
-      nav.appendChild(next);
-    }
-
-    main.innerHTML = "";
-    main.appendChild(hero);
-    main.appendChild(grid);
-    main.appendChild(nav);
-  }
-
-  function formatCourseLabel(label) {
-    const text = label.textContent.trim();
-    const courseText = text.replace(/^Course:\s*/i, "");
-    label.textContent = "";
-    label.classList.add("course-label");
-    label.appendChild(createElement("strong", "", "Course"));
-    label.appendChild(document.createTextNode(" " + courseText));
-    return courseText;
-  }
-
-  function buildLessonLinks(volumeSlug, chapterNumber, dayNumber, chapterCount, daysPerChapter) {
-    const basePath = "/programs/Bachelor-Liberal-Arts/" + volumeSlug + "/schedule/";
-    const chapterPath = basePath + "chapter-" + pad(chapterNumber) + "/index.html";
-    let previousPath = chapterPath;
-    let nextPath = basePath + "index.html";
-
-    if (dayNumber > 1) {
-      previousPath = basePath + "chapter-" + pad(chapterNumber) + "/section-" + pad(dayNumber - 1) + ".html";
-    } else if (chapterNumber > 1) {
-      previousPath = basePath + "chapter-" + pad(chapterNumber - 1) + "/section-" + pad(daysPerChapter) + ".html";
-    }
-
-    if (dayNumber < daysPerChapter) {
-      nextPath = basePath + "chapter-" + pad(chapterNumber) + "/section-" + pad(dayNumber + 1) + ".html";
-    } else if (chapterNumber < chapterCount) {
-      nextPath = basePath + "chapter-" + pad(chapterNumber + 1) + "/section-01.html";
-    } else {
-      nextPath = "/programs/Bachelor-Liberal-Arts/index.html";
-    }
-
-    return {
-      previousPath: resolveSitePath(previousPath),
-      nextPath: resolveSitePath(nextPath),
-      chapterPath: resolveSitePath(chapterPath),
-      volumePath: resolveSitePath(basePath + "index.html")
-    };
-  }
-
-  // Courses that have their own subdirectory (canonical library courses)
-  var COURSE_DIRS = {
-    "LBS-101": true,
-    "LBS-105": true,
-    "LBS-110": true,
-    "LBS-120": true,
-    "LAB-101": true
-  };
-
-  function courseUrl(code) {
-    // code is like "LBS-101" or "LBS 101"
-    var normalized = code.replace(/\s+/, "-").toUpperCase();
-    if (COURSE_DIRS[normalized]) return "/courses/" + normalized + "/";
-    // Flat legacy courses
-    var flat = {
-      "LBS-201": "/courses/LBS-201-ethics-moral-reasoning.html",
-      "LBS-205": "/courses/LBS-205-writing-communication-ii.html",
-      "LBS-210": "/courses/LBS-210-mathematical-reasoning-proof.html",
-      "LBS-220": "/courses/LBS-220-scientific-method-experimental-design.html",
-      "LAB-201": "/courses/LAB-201-reasoning-lab-cases-debates.html",
-      "TECH-101": "/courses/TECH-101-coding-computational-thinking.html",
-      "TECH-201": "/courses/TECH-201-unmanned-systems.html",
-      "TECH-202": "/courses/TECH-202-ai-society.html",
-      "TECH-203": "/courses/TECH-203-cybersecurity-information-warfare.html",
-      "TECH-204": "/courses/TECH-204-hardware-hacking-embedded.html",
-      "TECH-205": "/courses/TECH-205-climate-tech-energy-systems.html",
-      "BUS-201": "/courses/BUS-201-entrepreneurship-startup-design.html",
-      "BUS-202": "/courses/BUS-202-finance-for-innovators.html",
-      "BUS-203": "/courses/BUS-203-organizational-leadership-negotiation.html",
-      "BUS-204": "/courses/BUS-204-global-markets-geopolitics.html",
-      "BUS-205": "/courses/BUS-205-business-ethics-responsibility.html",
-      "DATA-201": "/courses/DATA-201-data-science-visualization.html",
-      "HUM-201": "/courses/HUM-201-philosophy-of-consciousness.html",
-      "HUM-202": "/courses/HUM-202-political-theory-civic-life.html",
-      "HUM-203": "/courses/HUM-203-cultural-anthropology-fieldwork.html",
-      "HUM-204": "/courses/HUM-204-history-of-technology-innovation.html",
-      "HUM-205": "/courses/HUM-205-comparative-religion-society.html",
-      "LIFE-201": "/courses/LIFE-201-outdoor-leadership-expeditionary-skills.html",
-      "LIFE-202": "/courses/LIFE-202-health-fitness-human-performance.html",
-      "LIFE-203": "/courses/LIFE-203-psychology-creativity-flow-states.html",
-      "LIFE-204": "/courses/LIFE-204-education-mentorship-teach-what-you-know.html",
-      "LIFE-205": "/courses/LIFE-205-global-citizenship-civic-engagement.html",
-      "MEDIA-201": "/courses/MEDIA-201-film-visual-storytelling.html",
-      "MEDIA-202": "/courses/MEDIA-202-music-sound-design.html",
-      "MEDIA-203": "/courses/MEDIA-203-design-visual-communication.html",
-      "MEDIA-204": "/courses/MEDIA-204-creative-writing-story-craft.html",
-      "MEDIA-205": "/courses/MEDIA-205-media-culture-society.html",
-      "PSYCH-201": "/courses/PSYCH-201-human-psychology.html"
-    };
-    return flat[normalized] || null;
-  }
-
-  // Legacy map keyed by "LBS 101" style (space-separated) for backward compat
-  var COURSE_URLS = {};
-  (function() {
-    var codes = [
-      "LBS 101","LBS 105","LBS 110","LBS 120","LAB 101",
-      "LBS 201","LBS 205","LBS 210","LBS 220","LAB 201",
-      "TECH 101","TECH 201","TECH 202","TECH 203","TECH 204","TECH 205",
-      "BUS 201","BUS 202","BUS 203","BUS 204","BUS 205",
-      "DATA 201","HUM 201","HUM 202","HUM 203","HUM 204","HUM 205",
-      "LIFE 201","LIFE 202","LIFE 203","LIFE 204","LIFE 205",
-      "MEDIA 201","MEDIA 202","MEDIA 203","MEDIA 204","MEDIA 205",
-      "PSYCH 201"
-    ];
-    codes.forEach(function(c) { COURSE_URLS[c] = courseUrl(c); });
-  })();
-
-  function buildLessonTopbar(meta, links) {
-    var topbar = createElement("div", "lesson-topbar");
-
-    var pos = createElement("span", "lesson-pos",
-      "Week " + meta.chapterNumber + " \u00b7 Day " + meta.dayNumber + " of " + meta.volume.daysPerChapter
-    );
-
-    var nav = createElement("div", "lesson-nav");
-    var prev = createElement("a", "", "\u2190 Prev");
-    prev.href = links.previousPath;
-    var chap = createElement("a", "", "Week " + meta.chapterNumber);
-    chap.href = links.chapterPath;
-    var next = createElement("a", "", "Next \u2192");
-    next.href = links.nextPath;
-    nav.appendChild(prev);
-    nav.appendChild(chap);
-    nav.appendChild(next);
-
-    topbar.appendChild(pos);
-    topbar.appendChild(nav);
-    return topbar;
-  }
-
-  function buildDayRail(meta, links) {
-    var rail = createElement("section", "day-rail");
-
-    var label = createElement("p", "day-rail-label", "Week " + meta.chapterNumber);
-    rail.appendChild(label);
-
-    var grid = createElement("div", "day-rail-grid");
-    for (var i = 1; i <= meta.volume.daysPerChapter; i++) {
-      var a = createElement("a", i === meta.dayNumber ? "is-current" : "", String(i));
-      a.href = resolveSitePath(
-        "/programs/Bachelor-Liberal-Arts/" + meta.volumeSlug +
-        "/schedule/chapter-" + pad(meta.chapterNumber) +
-        "/section-" + pad(i) + ".html"
-      );
-      a.setAttribute("aria-label", "Day " + i);
-      grid.appendChild(a);
-    }
-    rail.appendChild(grid);
-
-    var links2 = createElement("div", "lesson-nav");
-    var ch = createElement("a", "", "Week overview");
-    ch.href = links.chapterPath;
-    var vol = createElement("a", "", "Full schedule");
-    vol.href = links.volumePath;
-    links2.appendChild(ch);
-    links2.appendChild(vol);
-    rail.appendChild(links2);
-
-    return rail;
-  }
-
-  function buildLessonOutline(article) {
-    const headings = Array.from(article.querySelectorAll("h2, h3")).filter(function (heading) {
-      return !heading.closest(".lesson-topbar");
-    });
-
-    if (!headings.length) {
-      return null;
-    }
-
-    const outline = createElement("section", "lesson-outline");
-    outline.appendChild(createElement("h3", "", "On this page"));
-    const list = createElement("ul", "");
-
-    headings.forEach(function (heading) {
-      if (!heading.id) {
-        heading.id = slugify(heading.textContent || "section");
-      }
-      const item = createElement("li", "");
-      const link = createElement("a", "", heading.textContent || "");
-      link.href = "#" + heading.id;
-      item.appendChild(link);
-      list.appendChild(item);
-    });
-
-    outline.appendChild(list);
-    return outline;
-  }
-
-  /* ── Lesson section map ─────────────────────────────────── */
   var SECTION_CLASS_MAP = {
     "session-focus": "is-focus",
     "learning-objectives": "is-objectives",
@@ -709,6 +198,8 @@
     });
   }
 
+  /* ── Resource cards (Read / Watch / Listen links) ─────────── */
+
   function getYouTubeID(url) {
     var match = (url || "").match(/[?&]v=([^&]+)/) || (url || "").match(/youtu\.be\/([^?&]+)/);
     return match ? match[1] : null;
@@ -786,14 +277,15 @@
     });
   }
 
+  /* ── Course day pages (/courses/CODE/day-NN.html) ─────────── */
+
   function enhanceCourseLessonPage(path) {
     var courseId  = (path.match(/\/courses\/([A-Z]+-\d+)\//) || [])[1];
-    var dayNumber = parseInt((path.match(/\/day-(\d{2})\.html$/) || [])[1] || "0", 10);
+    var dayNumber = parseInt((path.match(/\/day-(\d{2})(?:\.html)?$/) || [])[1] || "0", 10);
     if (!courseId || !dayNumber) return;
 
     document.body.classList.add("lesson-page");
 
-    var ctx  = getProgramContext();
     var main = document.querySelector("main");
     if (!main) return;
 
@@ -810,46 +302,23 @@
 
     // ── Topbar ────────────────────────────────────────────────
     var topbar = createElement("div", "lesson-topbar");
-    var posLabel;
-    if (ctx) {
-      posLabel = createElement("span", "lesson-pos",
-        "Vol. " + ctx.vol.replace(/^vol-0*(\d+).*/, "$1") +
-        " \u00b7 Week " + ctx.week + " \u00b7 Day " + ctx.pos + " of 5"
-      );
-    } else {
-      posLabel = createElement("span", "lesson-pos",
-        courseId + " \u00b7 Day " + dayNumber + " of 15"
-      );
-    }
+    var posLabel = createElement("span", "lesson-pos",
+      courseId + " · Day " + dayNumber + " of 15"
+    );
 
     var topNav = createElement("div", "lesson-nav");
-    if (ctx) {
-      var backWeek = createElement("a", "",
-        "\u2190 Week " + ctx.week);
-      backWeek.href = resolveSitePath(
-        "/programs/Bachelor-Liberal-Arts/" + ctx.vol +
-        "/schedule/chapter-" + pad(ctx.week) + "/index.html"
-      );
-      var backSched = createElement("a", "", "Full Schedule");
-      backSched.href = resolveSitePath(
-        "/programs/Bachelor-Liberal-Arts/" + ctx.vol + "/schedule/index.html"
-      );
-      topNav.appendChild(backWeek);
-      topNav.appendChild(backSched);
-    } else {
-      if (dayNumber > 1) {
-        var p = createElement("a", "", "\u2190 Day " + (dayNumber - 1));
-        p.href = resolveSitePath("/courses/" + courseId + "/day-" + pad(dayNumber - 1) + ".html");
-        topNav.appendChild(p);
-      }
-      var cLink = createElement("a", "", courseId);
-      cLink.href = resolveSitePath("/courses/" + courseId + "/");
-      topNav.appendChild(cLink);
-      if (dayNumber < 15) {
-        var nx = createElement("a", "", "Day " + (dayNumber + 1) + " \u2192");
-        nx.href = resolveSitePath("/courses/" + courseId + "/day-" + pad(dayNumber + 1) + ".html");
-        topNav.appendChild(nx);
-      }
+    if (dayNumber > 1) {
+      var p = createElement("a", "", "← Day " + (dayNumber - 1));
+      p.href = resolveSitePath("/courses/" + courseId + "/day-" + pad(dayNumber - 1) + ".html");
+      topNav.appendChild(p);
+    }
+    var cLink = createElement("a", "", courseId);
+    cLink.href = resolveSitePath("/courses/" + courseId + "/");
+    topNav.appendChild(cLink);
+    if (dayNumber < 15) {
+      var nx = createElement("a", "", "Day " + (dayNumber + 1) + " →");
+      nx.href = resolveSitePath("/courses/" + courseId + "/day-" + pad(dayNumber + 1) + ".html");
+      topNav.appendChild(nx);
     }
     topbar.appendChild(posLabel);
     topbar.appendChild(topNav);
@@ -859,25 +328,12 @@
 
     // ── Sidebar rail ──────────────────────────────────────────
     var rail  = createElement("section", "day-rail");
-    var rlabel = createElement("p", "day-rail-label",
-      ctx ? "Week " + ctx.week : courseId);
-    rail.appendChild(rlabel);
+    rail.appendChild(createElement("p", "day-rail-label", courseId));
 
     var railGrid = createElement("div", "day-rail-grid");
-    var totalDays = ctx ? 5 : 15;
-    var currentNum = ctx ? ctx.pos : dayNumber;
-    for (var i = 1; i <= totalDays; i++) {
-      var a = createElement("a", i === currentNum ? "is-current" : "", String(i));
-      if (ctx) {
-        // Navigate between course days via week overview (we don't know sibling course IDs here)
-        a.href = resolveSitePath(
-          "/programs/Bachelor-Liberal-Arts/" + ctx.vol +
-          "/schedule/chapter-" + pad(ctx.week) + "/index.html"
-        );
-        a.setAttribute("title", "Day " + i + " — go to week overview");
-      } else {
-        a.href = resolveSitePath("/courses/" + courseId + "/day-" + pad(i) + ".html");
-      }
+    for (var i = 1; i <= 15; i++) {
+      var a = createElement("a", i === dayNumber ? "is-current" : "", String(i));
+      a.href = resolveSitePath("/courses/" + courseId + "/day-" + pad(i) + ".html");
       a.setAttribute("aria-label", "Day " + i);
       railGrid.appendChild(a);
     }
@@ -887,35 +343,8 @@
     var overviewLink = createElement("a", "", "Course overview");
     overviewLink.href = resolveSitePath("/courses/" + courseId + "/");
     railLinks.appendChild(overviewLink);
-    if (ctx) {
-      var weekLink = createElement("a", "", "Week " + ctx.week + " overview");
-      weekLink.href = resolveSitePath(
-        "/programs/Bachelor-Liberal-Arts/" + ctx.vol +
-        "/schedule/chapter-" + pad(ctx.week) + "/index.html"
-      );
-      railLinks.appendChild(weekLink);
-    }
     rail.appendChild(railLinks);
     sidebar.appendChild(rail);
-
-    // ── Course source link ────────────────────────────────────
-    var firstH1 = article.querySelector("h1");
-    var courseLabel = Array.from(article.querySelectorAll("p")).find(function(p) {
-      return /^Course:\s*/i.test(p.textContent.trim());
-    });
-    if (courseLabel && firstH1) {
-      var courseName = formatCourseLabel(courseLabel);
-      var codeKey = courseName.split(/[\u2013\-]/)[0].trim();
-      var cUrl = COURSE_URLS[codeKey] || resolveSitePath("/courses/" + courseId + "/");
-      var src = createElement("p", "lesson-course-source");
-      src.appendChild(document.createTextNode(courseName + " \u00b7 "));
-      var srcLink = createElement("a", "lesson-course-link", "View full course \u2192");
-      srcLink.href = resolveSitePath(cUrl);
-      src.appendChild(srcLink);
-      var after = firstH1.nextSibling;
-      if (after) article.insertBefore(src, after);
-      else article.appendChild(src);
-    }
 
     wrapLessonSections(article);
     enhanceResourceLinks(article);
@@ -923,152 +352,32 @@
 
   function enhanceLessonPage() {
     const path = currentPath();
-    const isCourseDayPage = /\/courses\/[A-Z]+-\d+\/day-\d{2}\.html$/.test(path);
-    if (isCourseDayPage) {
+    if (/\/courses\/[A-Z]+-\d+\/day-\d{2}(\.html)?$/.test(path)) {
       enhanceCourseLessonPage(path);
-      return;
-    }
-    if (!/\/section-\d{2}\.html$/.test(path)) {
-      return;
-    }
-
-    const volumeSlug = getVolumeSlug(path);
-    const volume = getVolumeData(path);
-    const chapterNumber = getChapterNumber(path);
-    const dayNumber = getDayNumber(path);
-    const main = document.querySelector("main");
-
-    if (!volumeSlug || !volume || !chapterNumber || !dayNumber || !main) {
-      return;
-    }
-
-    document.body.classList.add("lesson-page");
-
-    const breadcrumbs = main.querySelector(".breadcrumbs");
-    if (breadcrumbs) {
-      const activeCrumb = breadcrumbs.querySelector("strong");
-      if (activeCrumb) {
-        activeCrumb.textContent = "Day " + dayNumber;
-      }
-    }
-
-    const firstHeading = main.querySelector("h1");
-    if (firstHeading && /^Section\s+/i.test(firstHeading.textContent || "")) {
-      firstHeading.textContent = (firstHeading.textContent || "").replace(/^Section/i, "Day");
-    }
-
-    let courseName = "";
-    const courseLabel = Array.from(main.querySelectorAll("p")).find(function (paragraph) {
-      return /^Course:\s*/i.test(paragraph.textContent.trim());
-    });
-    if (courseLabel) {
-      courseName = formatCourseLabel(courseLabel);
-    }
-
-    let shell = main.querySelector(".lesson-shell");
-    let article;
-    let sidebar;
-
-    if (!shell) {
-      const nodesToMove = Array.from(main.childNodes).filter(function (node) {
-        return node !== breadcrumbs;
-      });
-
-      shell = createElement("div", "lesson-shell");
-      article = createElement("article", "lesson-content");
-      sidebar = createElement("aside", "lesson-sidebar");
-
-      nodesToMove.forEach(function (node) {
-        article.appendChild(node);
-      });
-
-      main.innerHTML = "";
-      if (breadcrumbs) {
-        main.appendChild(breadcrumbs);
-      }
-      shell.appendChild(article);
-      shell.appendChild(sidebar);
-      main.appendChild(shell);
-    } else {
-      article = shell.querySelector(".lesson-content");
-      sidebar = shell.querySelector(".lesson-sidebar");
-    }
-
-    const meta = {
-      volumeSlug: volumeSlug,
-      volume: volume,
-      chapterNumber: chapterNumber,
-      dayNumber: dayNumber
-    };
-    const links = buildLessonLinks(
-      meta.volumeSlug,
-      meta.chapterNumber,
-      meta.dayNumber,
-      meta.volume.chapters,
-      meta.volume.daysPerChapter
-    );
-
-    if (article && !article.querySelector(".lesson-topbar")) {
-      article.insertBefore(buildLessonTopbar(meta, links), article.firstChild);
-    }
-
-    if (sidebar) {
-      sidebar.innerHTML = "";
-      sidebar.appendChild(buildDayRail(meta, links));
-    }
-
-    if (article) {
-      // Inject course source link after the H1
-      if (firstHeading && courseName) {
-        var courseCode = courseName.split(/[\u2013\-]/)[0].trim();
-        var courseUrl = COURSE_URLS[courseCode];
-        var sourceEl = createElement("p", "lesson-course-source");
-        var sourceText = document.createTextNode(courseName + " \u00b7 ");
-        var sourceLink = createElement("a", "lesson-course-link", "View full course \u2192");
-        if (courseUrl) sourceLink.href = resolveSitePath(courseUrl);
-        sourceEl.appendChild(sourceText);
-        sourceEl.appendChild(sourceLink);
-        if (firstHeading.nextSibling) {
-          article.insertBefore(sourceEl, firstHeading.nextSibling);
-        } else {
-          article.appendChild(sourceEl);
-        }
-      }
-      wrapLessonSections(article);
-      enhanceResourceLinks(article);
     }
   }
+
+  /* ── Course overview pages (/courses/CODE/) ───────────────── */
 
   function getCourseCodeFromPath(pathname) {
-    // /courses/LBS-101/index.html  or  /courses/LBS-101/day-01.html  → "LBS-101"
-    var m = pathname.match(/\/courses\/([A-Z]+-\d+)\//);
-    if (m) return m[1];
-    // /courses/LBS-101-mental-gym.html  → "LBS-101"
-    var m2 = pathname.match(/\/courses\/([A-Z]+-\d+)/);
-    return m2 ? m2[1] : null;
-  }
-
-  function getProgramContext() {
-    if (typeof URLSearchParams === "undefined") return null;
-    var sp = new URLSearchParams(window.location.search);
-    var prog = sp.get("prog");
-    var vol  = sp.get("vol");
-    var week = parseInt(sp.get("week") || "0", 10);
-    var pos  = parseInt(sp.get("pos")  || "0", 10);
-    if (!prog || !vol || !week || !pos) return null;
-    return { prog: prog, vol: vol, week: week, pos: pos };
+    var m = pathname.match(/\/courses\/([A-Z]+-\d+)(\/|$)/);
+    return m ? m[1] : null;
   }
 
   function getCourseCategory(code) {
     var prefix = (code || "").split("-")[0];
     var cats = {
-      "LBS": "Liberal Arts",
-      "LAB": "Lab",
-      "TECH": "Technology",
-      "BUS": "Business",
-      "HUM": "Humanities",
-      "LIFE": "Life Skills",
-      "MEDIA": "Media & Arts"
+      "HUM": "The Canon",
+      "MATH": "Mathematics & Science",
+      "PHYS": "Mathematics & Science",
+      "CS": "Computation",
+      "RHET": "Rhetoric & Epistemics",
+      "SIG": "Culture & Signal",
+      "WKSP": "The Workshop",
+      "ART": "Depth Studio",
+      "ENGR": "Depth Studio",
+      "FLD": "Field Term",
+      "CAP": "Capstone"
     };
     return cats[prefix] || "Course";
   }
@@ -1076,10 +385,10 @@
   function enhanceCoursePage() {
     var path = currentPath();
     if (path.indexOf("/courses/") === -1) return;
-    // Allow /courses/LBS-101/index.html but exclude the top-level /courses/index.html
-    if (/^\/courses\/index\.html$/.test(path)) return;
+    // Allow /courses/CODE/ but exclude the top-level catalog page
+    if (/^\/courses\/(index(\.html)?)?$/.test(path)) return;
     // Exclude day pages — those are handled by enhanceCourseLessonPage
-    if (/\/day-\d{2}\.html$/.test(path)) return;
+    if (/\/day-\d{2}(\.html)?$/.test(path)) return;
 
     document.body.classList.add("course-page");
 
@@ -1088,17 +397,15 @@
     var h1 = main && main.querySelector("h1");
     if (!h1 || !code) return;
 
-    // Inject eyebrow with code badge + category
+    // Inject eyebrow with code badge + thread
     var eyebrow = createElement("div", "course-eyebrow");
-    var badge = createElement("span", "course-code-badge", code);
-    var cat = createElement("span", "course-category", getCourseCategory(code));
-    eyebrow.appendChild(badge);
-    eyebrow.appendChild(cat);
+    eyebrow.appendChild(createElement("span", "course-code-badge", code));
+    eyebrow.appendChild(createElement("span", "course-category", getCourseCategory(code)));
     h1.parentNode.insertBefore(eyebrow, h1);
 
-    // Strip course code prefix from H1 if present (e.g. "LBS-101 — Title" → "Title")
+    // Strip course code prefix from H1 if present ("CS 110 — Title" → "Title")
     var h1Text = h1.textContent || "";
-    var titleMatch = h1Text.match(/^[A-Z]+-\d+\s*[\u2014\-]\s*(.+)$/);
+    var titleMatch = h1Text.match(/^[A-Z]+[\s-]\d+\s*[—\-]\s*(.+)$/);
     if (titleMatch) h1.textContent = titleMatch[1];
 
     // Wrap H2 sections into course-section cards
@@ -1110,11 +417,7 @@
         return;
       }
       if (child.tagName === "H2") {
-        var text = (child.textContent || "").toLowerCase();
         var section = createElement("div", "course-section");
-        if (text.indexOf("central question") !== -1) section.classList.add("is-central-q");
-        else if (text.indexOf("arc") !== -1 || text.indexOf("15-day") !== -1) section.classList.add("is-arc");
-        else if (text.indexOf("make") !== -1 || text.indexOf("deliverable") !== -1) section.classList.add("is-deliverables");
         main.insertBefore(section, child);
         section.appendChild(child);
         currentSection = section;
@@ -1122,50 +425,12 @@
       }
       if (currentSection) currentSection.appendChild(child);
     });
-
-    // If this is a library course (subdirectory), append a 15-day grid
-    if (COURSE_DIRS[code] && /\/courses\/[A-Z]+-\d+\/(index\.html)?$/.test(path)) {
-      var daysSection = createElement("div", "course-section course-days-section");
-      var daysH2 = createElement("h2", "", "15 Daily Sessions");
-      daysSection.appendChild(daysH2);
-      var daysGrid = createElement("div", "course-days-grid");
-      for (var di = 1; di <= 15; di++) {
-        var dc = document.createElement("a");
-        dc.className = "course-day-card";
-        dc.href = resolveSitePath("/courses/" + code + "/day-" + pad(di) + ".html");
-        dc.appendChild(createElement("span", "course-day-num", "Day " + pad(di)));
-        dc.appendChild(createElement("span", "course-day-arrow", "\u2192"));
-        daysGrid.appendChild(dc);
-      }
-      daysSection.appendChild(daysGrid);
-      main.appendChild(daysSection);
-    }
   }
 
-  function tagGenericPages() {
-    const body = document.body;
-    const path = currentPath();
-
-    if (path === "/index.html") {
-      body.classList.add("home-page");
-    }
-
-    if (path === "/programs/index.html") {
-      body.classList.add("programs-page");
-    }
-
-    if (path === "/programs/Bachelor-Liberal-Arts/index.html") {
-      body.classList.add("program-page");
-    }
-  }
+  /* ── Boot ─────────────────────────────────────────────────── */
 
   function boot() {
-    tagGenericPages();
-    bindMobileNav();
     updateActiveNav();
-    enhanceCardGrids();
-    enhanceSectionCards();
-    enhanceChapterPage();
     enhanceLessonPage();
     enhanceCoursePage();
     if (typeof window.__sditRewritePaths === "function") {

--- a/assets/js/student-work.js
+++ b/assets/js/student-work.js
@@ -29,7 +29,7 @@
     // at both /courses/... and the schedule route, and responses must be one set.
     var meta = document.querySelector('meta[name="sdit-lesson"]');
     if (meta && meta.content) return meta.content;
-    // /courses/LBS-101/day-01.html  →  /courses/LBS-101/day-01
+    // /courses/HUM-101/day-01.html  →  /courses/HUM-101/day-01
     return location.pathname.replace(/\.html$/, "");
   }
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -50,185 +50,6 @@ p, ul, ol, blockquote, pre, table { margin: 0 0 1rem; }
 ul, ol { padding-left: 1.25rem; }
 li + li { margin-top: 0.4rem; }
 
-/* ─── Header ────────────────────────────────────────────────────────────────── */
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: var(--bg);
-  border-bottom: 1px solid var(--hairline);
-}
-
-.site-header-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  max-width: var(--max);
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  height: 3.75rem;
-}
-
-.site-brand-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex: 1;
-}
-
-.site-brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.7rem;
-  text-decoration: none;
-}
-
-.site-brand-mark {
-  width: 2.4rem;
-  height: 2.2rem;
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.site-brand-mark img { width: 100%; height: 100%; object-fit: contain; }
-
-.site-brand-copy { display: grid; gap: 0.05rem; }
-.site-brand-copy strong { font-size: 0.9rem; font-weight: 700; color: var(--ink); letter-spacing: -0.01em; }
-.site-brand-copy small { font-size: 0.72rem; color: var(--muted); }
-
-.site-nav-toggle {
-  display: none;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.5rem 0.8rem;
-  border: 1px solid var(--border-strong);
-  border-radius: 0;
-  background: transparent;
-  color: var(--ink);
-  font: inherit;
-  font-size: 0.85rem;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.site-nav-toggle__icon,
-.site-nav-toggle__icon::before,
-.site-nav-toggle__icon::after {
-  display: block;
-  width: 0.9rem;
-  height: 1.5px;
-  background: currentColor;
-  border-radius: 0;
-  transition: transform 130ms, opacity 130ms;
-}
-.site-nav-toggle__icon { position: relative; }
-.site-nav-toggle__icon::before,
-.site-nav-toggle__icon::after { content: ""; position: absolute; left: 0; }
-.site-nav-toggle__icon::before { top: -0.28rem; }
-.site-nav-toggle__icon::after  { top:  0.28rem; }
-.site-header.is-nav-open .site-nav-toggle__icon { background: transparent; }
-.site-header.is-nav-open .site-nav-toggle__icon::before { transform: translateY(0.28rem) rotate(45deg); }
-.site-header.is-nav-open .site-nav-toggle__icon::after  { transform: translateY(-0.28rem) rotate(-45deg); }
-
-.site-nav {
-  display: flex;
-  align-items: center;
-  gap: 0.15rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.site-nav a {
-  padding: 0.35rem 0.6rem;
-  text-decoration: none;
-  color: var(--muted);
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.72rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  transition: color 150ms;
-}
-.site-nav a:hover { color: var(--gold); background: transparent; }
-.site-nav a[aria-current="page"] { color: var(--ink); background: transparent; }
-
-.site-nav .nav-cta {
-  padding: 0.35rem 0.75rem;
-  border: 1px solid var(--gold);
-  color: var(--gold);
-  font-weight: 600;
-  background: transparent;
-}
-.site-nav .nav-cta:hover { background: var(--gold); color: var(--ink); }
-
-/* ─── Footer ────────────────────────────────────────────────────────────────── */
-.site-footer {
-  margin-top: auto;
-  border-top: 1px solid var(--hairline);
-  padding: 0 1.5rem 3rem;
-}
-
-.site-footer-inner {
-  display: grid;
-  grid-template-columns: 1.5fr 1fr 1fr;
-  gap: 2rem;
-  max-width: var(--max);
-  margin: 0 auto;
-  padding: 2.5rem 0 0;
-}
-
-.site-footer-title {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.68rem;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--gold);
-  margin: 0 0 0.85rem;
-}
-
-.site-footer-copy > p { color: var(--muted); font-size: 0.92rem; line-height: 1.75; margin: 0; }
-
-.site-footer-links a,
-.site-footer-meta a {
-  display: block;
-  color: var(--ink-soft);
-  text-decoration: none;
-  font-size: 0.88rem;
-  font-weight: 400;
-  margin-bottom: 0.45rem;
-  transition: color 150ms;
-}
-.site-footer-links a:hover,
-.site-footer-meta a:hover { color: var(--gold); }
-
-/* ─── Inner-page main ───────────────────────────────────────────────────────── */
-main:not(.home-main) {
-  max-width: var(--max);
-  margin: 0 auto;
-  padding: 3rem 1.5rem 6rem;
-}
-
-/* ─── Breadcrumbs ────────────────────────────────────────────────────────────── */
-.breadcrumbs {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.4rem;
-  margin-bottom: 1.25rem;
-  color: var(--muted);
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-.breadcrumbs a { color: var(--muted); text-decoration: none; transition: color 150ms; }
-.breadcrumbs a:hover { color: var(--gold); }
-.breadcrumbs .sep { opacity: 0.4; }
-
 /* ─── Utility labels ──────────────────────────────────────────────────────────── */
 .eyebrow, .card-kicker, .mini-label {
   display: inline-flex;
@@ -241,31 +62,6 @@ main:not(.home-main) {
   text-transform: uppercase;
   color: var(--gold);
 }
-
-.status-pill, .day-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.5rem;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.68rem;
-  font-weight: 500;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  border: 1px solid var(--hairline);
-  background: transparent;
-  color: var(--muted);
-}
-.status-pill.is-live {
-  background: var(--live-soft);
-  color: var(--live);
-  border-color: rgba(22, 101, 52, 0.25);
-}
-.status-pill.is-soon {
-  background: var(--gold-soft);
-  color: var(--gold);
-  border-color: var(--gold);
-}
-.status-pill.is-building { background: transparent; color: var(--muted); }
 
 /* ─── Buttons ──────────────────────────────────────────────────────────────── */
 .btn {
@@ -296,17 +92,6 @@ main:not(.home-main) {
   border-color: var(--ink);
   color: var(--ink);
 }
-.view-link, .text-link {
-  color: var(--marine);
-  font-weight: 500;
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
-  transition: color 150ms;
-}
-.view-link:hover, .text-link:hover { color: var(--gold); }
-
-.cta-buttons, .button-row { display: flex; flex-wrap: wrap; gap: 0.65rem; }
 
 /* ─── Cards (inner pages) ───────────────────────────────────────────────────── */
 .card, .feature-card, .volume-card, .year-card, .chapter-card {
@@ -321,140 +106,28 @@ main:not(.home-main) {
   font-size: 1.1rem;
   line-height: 1.25;
 }
-.volume-card { display: grid; gap: 0.65rem; }
 .meta, .subtitle, .tagline { color: var(--muted); }
-.card-actions { display: flex; flex-wrap: wrap; gap: 0.55rem; margin-top: 0.85rem; }
-
-/* ─── Section panel (inner pages) ─────────────────────────────────────────── */
-.section-panel {
-  margin-top: 1.25rem;
-  padding: 1.75rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-xl);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-.section-heading { display: grid; gap: 0.45rem; margin-bottom: 1.4rem; }
-.section-heading h2, .section-heading h3 {
-  margin: 0;
-  font-weight: 700;
-  line-height: 1.1;
-  letter-spacing: -0.025em;
-  font-size: clamp(1.6rem, 3vw, 2.4rem);
-  max-width: 22ch;
-}
-.section-heading p { max-width: 60ch; color: var(--muted); }
-
-/* ─── Grids ─────────────────────────────────────────────────────────────────── */
-.feature-grid, .card-grid, .volume-grid, .cards-grid, .explore-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 1rem;
-}
-.year-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1rem; }
-.about-grid { display: grid; grid-template-columns: minmax(0,1.2fr) repeat(2, minmax(210px,1fr)); gap: 1rem; }
-.explore-card, .about-card {
-  display: grid; gap: 0.8rem; padding: 1.35rem;
-  border: 1px solid var(--border); border-radius: var(--r-lg);
-  background: var(--surface); box-shadow: var(--shadow);
-}
-.explore-card h3, .about-card h3 { margin: 0; font-size: 1.05rem; }
-.explore-card p, .about-card p { color: var(--muted); font-size: 0.92rem; margin: 0; }
-
-/* ─── Directory links ───────────────────────────────────────────────────────── */
-.directory-link {
-  display: flex; justify-content: space-between; align-items: center;
-  gap: 1rem; padding: 0.8rem 0.95rem;
-  border: 1px solid var(--hairline); border-bottom-width: 1px;
-  background: transparent; color: var(--ink);
-  text-decoration: none; font-weight: 500; font-size: 0.9rem;
-  transition: border-color 150ms, color 150ms;
-}
-.directory-link small { color: var(--muted); font-size: 0.8rem; font-weight: 400; }
-.directory-link:hover { border-color: var(--ink); color: var(--marine); }
-.directory-stack, .directory-group, .link-stack, .quick-stack { display: grid; gap: 0.6rem; }
-.directory-links { display: grid; gap: 0.45rem; }
-.directory-group strong { display: block; font-size: 0.86rem; color: var(--muted); margin-bottom: 0.1rem; }
-
-/* ─── Metrics ───────────────────────────────────────────────────────────────── */
-.metric-grid, .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 0.8rem; }
-.metric-card, .stat-card, .mini-card {
-  padding: 0.95rem 1rem;
-  border: 1px solid var(--border); border-radius: var(--r-md);
-  background: var(--surface-soft);
-}
-.metric-card strong, .stat-card strong { display: block; font-size: 1.4rem; font-weight: 700; }
-.metric-card span, .stat-card span { display: block; color: var(--muted); font-size: 0.84rem; }
-.mini-card { display: grid; gap: 0.35rem; }
-.mini-card strong { display: block; font-size: 0.97rem; font-weight: 700; }
-.mini-card span { color: var(--muted); font-size: 0.87rem; }
-
-/* ─── Search ─────────────────────────────────────────────────────────────────── */
-.search-bar { max-width: 380px; margin-bottom: 1.1rem; }
-.search-bar input {
-  width: 100%; min-height: 2.85rem; padding: 0.75rem 0.95rem;
-  border: 1px solid var(--border); border-radius: var(--r-md);
-  background: var(--surface); color: var(--ink); font: inherit;
-}
-.search-bar input:focus {
-  outline: none; border-color: var(--hairline);
-  box-shadow: none;
-}
-
-/* ─── Mini points ────────────────────────────────────────────────────────────── */
-.mini-points, .inline-list { display: flex; flex-wrap: wrap; gap: 0.55rem; margin-top: 1.25rem; }
-.mini-points span, .inline-list span {
-  display: inline-flex; align-items: center; gap: 0.35rem;
-  padding: 0.45rem 0.7rem; border-radius: var(--r-sm);
-  border: 1px solid var(--border); background: var(--surface-soft);
-  color: var(--ink-soft); font-size: 0.85rem; font-weight: 600;
-}
-
-/* ─── Program cards ──────────────────────────────────────────────────────────── */
-.program-card-list { display: grid; gap: 0.85rem; }
-.program-card {
-  display: grid; grid-template-columns: 1fr auto; gap: 1rem;
-  align-items: center; padding: 1.35rem;
-  border: 1px solid var(--border); border-radius: var(--r-lg);
-  background: var(--surface); box-shadow: var(--shadow);
-}
-.program-card p { color: var(--muted); margin: 0; }
-
-/* ─── Term / Year cards ──────────────────────────────────────────────────────── */
-.term-list { display: grid; gap: 0.6rem; }
-.term-card {
-  display: grid; gap: 0.25rem; padding: 0.9rem 1rem;
-  border: 1px solid var(--border); border-radius: var(--r-md);
-  background: var(--surface-soft); text-decoration: none;
-  transition: background 110ms, border-color 110ms;
-}
-.term-card:hover { background: var(--accent-soft); border-color: var(--hairline); }
-.term-card strong { font-size: 0.93rem; }
-.term-card small { color: var(--muted); font-size: 0.85rem; }
-.year-card { display: grid; gap: 0.85rem; }
-.year-card-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.85rem; }
-.year-card-meta { color: var(--muted); font-size: 0.9rem; }
 
 /* ─── Hero (inner pages only) ───────────────────────────────────────────────── */
 .hero { display: grid; gap: 1.1rem; margin-bottom: 1.75rem; }
-.hero.hero-split { grid-template-columns: minmax(0,1.4fr) minmax(250px,0.9fr); }
 .hero-copy, .hero-panel, .hero > :only-child {
   padding: 1.6rem 1.8rem;
   border: 1px solid var(--border); border-radius: var(--r-xl);
   background: var(--surface); box-shadow: var(--shadow-md);
 }
-.hero.hero-compact .hero-copy,
-.hero.hero-compact .hero-panel { padding: 1.35rem 1.5rem; }
 .hero h1, .hero h2, main:not(.home-main) > h1, main:not(.home-main) > h2 {
   margin: 0; font-weight: 700; line-height: 1.05; letter-spacing: -0.03em;
 }
 .hero h1, .hero h2 { font-size: clamp(2rem, 4.5vw, 3.6rem); max-width: 12ch; }
-.hero.hero-compact h1, .hero.hero-compact h2 { font-size: clamp(1.8rem, 4vw, 2.8rem); }
 .hero p, .hero .lead, .hero .desc { color: var(--muted); max-width: 50ch; }
 .hero .lead { font-size: 1rem; }
-.hero-panel { display: grid; gap: 0.9rem; align-content: start; }
-.hero-copy .cta-buttons, .hero-copy .button-row { margin-top: 1.1rem; }
-.hero-copy .mini-points { margin-top: 0.9rem; }
+
+/* ─── Inner-page main ───────────────────────────────────────────────────────── */
+main:not(.home-main) {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 6rem;
+}
 
 /* ─── Lesson page ────────────────────────────────────────────────────────────── */
 .lesson-page main { padding-top: 1.75rem; }
@@ -498,13 +171,6 @@ main:not(.home-main) {
 .day-rail-grid a:hover { background: var(--accent-soft); border-color: var(--hairline); color: var(--accent); }
 .day-rail-grid a.is-current { background: var(--accent); border-color: var(--accent); color: #fff; }
 .day-rail-label { font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); margin: 0 0 0.5rem; }
-.lesson-course-source {
-  margin: 0.1rem 0 0; font-size: 0.85rem; color: var(--muted);
-}
-.lesson-course-link {
-  color: var(--accent); text-decoration: none; font-weight: 700;
-}
-.lesson-course-link:hover { text-decoration: underline; }
 .lesson-content h1 { font-size: clamp(1.7rem, 3.5vw, 2.6rem); margin: 0 0 0.2rem; font-family: 'EB Garamond', Georgia, serif; font-weight: 400; }
 
 /* ─── Lesson sections ───────────────── */
@@ -613,25 +279,6 @@ main:not(.home-main) {
 .resource-link-title { font-size: 0.9rem; font-weight: 700; color: var(--ink); }
 .resource-link-sub { font-size: 0.78rem; color: var(--muted); text-decoration: none; }
 .resource-link-sub:hover { color: var(--accent); text-decoration: underline; }
-.lesson-spotlight {
-  display: grid; grid-template-columns: minmax(0,1.3fr) minmax(270px,0.9fr);
-  gap: 1rem; margin: 1.25rem 0 1.5rem;
-}
-.lesson-spotlight-copy, .lesson-progress-card, .lesson-challenge {
-  padding: 1.25rem; border: 1px solid var(--border);
-  border-radius: var(--r-lg); background: var(--surface); box-shadow: var(--shadow);
-  display: grid; gap: 0.75rem; align-content: start;
-}
-.lesson-lead { margin: 0; font-size: 1.05rem; color: var(--ink-soft); line-height: 1.6; }
-.lesson-progress-meter {
-  width: 100%; height: 0.6rem; overflow: hidden; border-radius: 0;
-  background: var(--accent-soft);
-}
-.lesson-progress-meter span {
-  display: block; width: 0; height: 100%; border-radius: inherit;
-  background: var(--accent); transition: width 200ms ease;
-}
-.lesson-progress-copy { margin: 0; }
 .lesson-checklist { display: grid; gap: 0.6rem; }
 .lesson-checklist label {
   display: grid; grid-template-columns: auto 1fr; gap: 0.6rem;
@@ -640,571 +287,13 @@ main:not(.home-main) {
   background: var(--surface-soft); color: var(--ink-soft); font-weight: 600; cursor: pointer;
 }
 .lesson-checklist input { margin: 0.12rem 0 0; accent-color: var(--marine); }
-.lesson-resource-grid, .lesson-practice-grid { grid-template-columns: repeat(2, minmax(0,1fr)); }
 .resource-card, .prompt-card {
   padding: 1.2rem; border: 1px solid var(--border);
   border-radius: var(--r-lg); background: var(--surface); box-shadow: var(--shadow);
   display: grid; gap: 0.75rem; align-content: start;
 }
 .resource-card h4, .prompt-card h4, .lesson-challenge h4 { margin: 0; font-size: 1rem; line-height: 1.3; }
-.resource-embed {
-  position: relative; overflow: hidden;
-  border: 1px solid var(--border); border-radius: var(--r-md);
-  background: #0a1426; aspect-ratio: 16/9;
-}
-.resource-embed iframe { width: 100%; height: 100%; border: 0; }
-.resource-notes {
-  padding: 0.7rem 0.85rem; border: 1px solid var(--border);
-  border-radius: var(--r-md); background: var(--surface-soft);
-}
-.resource-notes summary { cursor: pointer; font-weight: 700; color: var(--accent); }
-.resource-notes ul { margin: 0.7rem 0 0; }
-.lesson-workbench {
-  display: grid; grid-template-columns: minmax(0,0.85fr) minmax(0,1.15fr);
-  gap: 1rem; margin-top: 0.9rem;
-}
-.field-label { display: block; color: var(--muted); font-size: 0.87rem; margin-bottom: 0.25rem; }
-.lesson-workbench textarea {
-  width: 100%; min-height: 7.5rem; padding: 0.85rem 0.95rem;
-  border: 1px solid var(--border); border-radius: var(--r-md);
-  background: var(--surface-soft); color: var(--ink); font: inherit; resize: vertical;
-}
-.lesson-workbench textarea:focus {
-  outline: none; border-color: var(--hairline);
-  box-shadow: none;
-}
-.lesson-challenge { background: var(--surface-soft); }
-.course-label {
-  display: inline-flex; align-items: center; gap: 0.4rem; width: fit-content;
-  padding: 0.55rem 0.8rem; border-radius: var(--r-sm);
-  border: 1px solid var(--border); background: var(--accent-soft);
-  color: var(--accent); font-size: 0.87rem; font-weight: 700;
-}
 .chapter-page .hero, .lesson-page .hero { grid-template-columns: 1fr; }
-.chapter-page .hero .icon {
-  width: 3rem; height: 3rem; border-radius: var(--r-md);
-  border: 1px solid var(--border); background: var(--accent-soft);
-  color: var(--accent); display: inline-flex; align-items: center;
-  justify-content: center; font-size: 1.4rem;
-}
-.overview-strip { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px,1fr)); gap: 0.7rem; margin-top: 0.9rem; }
-.split-callout { display: grid; grid-template-columns: minmax(0,1fr) minmax(290px,0.9fr); gap: 1.1rem; align-items: start; }
-.chapter-toolbar { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-top: 0.9rem; }
-.cards-grid { padding: 0; margin: 0; list-style: none; display: grid; gap: 0.85rem; grid-template-columns: repeat(auto-fit, minmax(230px,1fr)); }
-.cards-grid .section-item, .cards-grid .chapter-item {
-  list-style: none; padding: 1.2rem; border: 1px solid var(--border);
-  border-radius: var(--r-lg); background: var(--surface); box-shadow: var(--shadow);
-}
-.cards-grid .section-item a, .cards-grid .chapter-item a { display: grid; gap: 0.6rem; text-decoration: none; }
-.section-item__title { font-size: 1rem; font-weight: 700; line-height: 1.3; }
-.section-arrow { color: var(--accent); font-size: 0.87rem; font-weight: 700; }
-.lesson-notes-reset, .lesson-reset { justify-self: start; }
-
-/* ─── Legacy page headers ───────────────────────────────────────────────────── */
-body > header:not(.site-header) { padding: 3.5rem 1.5rem 1.25rem; }
-body > header:not(.site-header)::before {
-  content: ""; display: block; width: 5rem; height: 4.5rem;
-  margin: 0 auto 1rem;
-  background: url("brand/sdit-crest.png?v=20260313") center/contain no-repeat;
-}
-body > header:not(.site-header) h1 {
-  max-width: var(--max); margin: 0 auto;
-  padding: 2rem 2.2rem; border: 1px solid var(--border);
-  border-radius: var(--r-xl); background: var(--surface); box-shadow: var(--shadow-md);
-  font-weight: 700; font-size: clamp(1.9rem, 4.5vw, 3.2rem); line-height: 1.06;
-}
-
-/* ════════════════════════════════════════════════════════════════════════════
-   HOME PAGE
-   ════════════════════════════════════════════════════════════════════════════ */
-.home-page { background: var(--bg); }
-
-.home-main { display: flex; flex-direction: column; }
-
-/* Entry */
-.home-entry {
-  padding: 5rem 1.5rem 4.5rem;
-  text-align: center;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-}
-
-.home-entry-inner {
-  max-width: 680px;
-  margin: 0 auto;
-  display: grid;
-  gap: 1.25rem;
-}
-
-.home-entry h1 {
-  margin: 0;
-  font-family: 'EB Garamond', Georgia, serif;
-  font-weight: 400;
-  font-size: clamp(2.6rem, 5.5vw, 4.2rem);
-  line-height: 1.1;
-  letter-spacing: -0.01em;
-  color: var(--ink);
-}
-
-.home-entry p {
-  margin: 0 auto;
-  max-width: 52ch;
-  font-size: 1.05rem;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
-.home-start-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.8rem 1.75rem;
-  border: 1px solid var(--ink);
-  background: var(--ink);
-  color: var(--bg);
-  font-weight: 500;
-  font-size: 0.95rem;
-  text-decoration: none;
-  transition: background 150ms, border-color 150ms;
-  margin: 0 auto;
-  width: fit-content;
-}
-.home-start-btn:hover { background: var(--marine); border-color: var(--marine); }
-
-/* Philosophy */
-.home-philosophy {
-  background: var(--surface);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  padding: 5rem 1.5rem;
-}
-
-.home-philosophy-inner {
-  max-width: var(--max);
-  margin: 0 auto;
-  display: grid;
-  gap: 3.5rem;
-}
-
-.home-phi-intro {
-  max-width: 800px;
-}
-
-.home-phi-intro h2 {
-  margin: 0.5rem 0 1.1rem;
-  font-family: 'EB Garamond', Georgia, serif;
-  font-weight: 400;
-  font-size: clamp(1.9rem, 4vw, 3rem);
-  line-height: 1.15;
-  letter-spacing: -0.01em;
-  color: var(--ink);
-}
-
-.home-phi-intro > p {
-  color: var(--muted);
-  font-size: 1rem;
-  line-height: 1.8;
-  max-width: 64ch;
-  margin: 0 0 0.9rem;
-}
-
-.home-phi-principles {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2rem 4rem;
-}
-
-.home-phi-block h3 {
-  margin: 0 0 0.5rem;
-  font-size: 0.97rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--ink);
-}
-
-.home-phi-block p {
-  color: var(--muted);
-  font-size: 0.93rem;
-  line-height: 1.75;
-  margin: 0;
-}
-
-/* Path */
-.home-path {
-  padding: 3.5rem 1.5rem 5rem;
-}
-
-.home-path-inner {
-  max-width: var(--max);
-  margin: 0 auto;
-  display: grid;
-  gap: 2.5rem;
-}
-
-.home-path-header {
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--border);
-}
-.home-path-header h2 {
-  margin: 0.4rem 0 0.65rem;
-  font-weight: 700;
-  font-size: clamp(1.4rem, 3vw, 1.9rem);
-  letter-spacing: -0.02em;
-  line-height: 1.15;
-}
-.home-path-header > p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.95rem;
-  max-width: 58ch;
-  line-height: 1.7;
-}
-
-.home-path-year {
-  display: grid;
-  grid-template-columns: 7rem 1fr;
-  gap: 1.5rem;
-  align-items: start;
-}
-
-.home-path-year-label {
-  padding-top: 1.1rem;
-}
-
-.home-path-year-label span {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.home-path-volumes {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-
-.home-path-vol {
-  display: grid;
-  gap: 0.5rem;
-  padding: 1.4rem 1.5rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-  text-decoration: none;
-  color: var(--ink);
-  box-shadow: var(--shadow);
-  transition: border-color 130ms, box-shadow 130ms;
-  align-content: start;
-}
-
-.home-path-vol:hover {
-  border-color: var(--hairline);
-  box-shadow: var(--shadow-md);
-}
-
-.home-path-vol.is-active {
-  border-color: var(--hairline);
-  background: #fff;
-}
-
-.home-path-vol.is-planned {
-  background: var(--surface-soft);
-  box-shadow: none;
-}
-
-.home-path-vol.is-planned strong,
-.home-path-vol.is-planned p { opacity: 0.6; }
-
-.home-path-vol-meta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.home-path-vol-num {
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.home-path-vol-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.5rem;
-  border-radius: 0;
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid transparent;
-}
-
-.home-path-vol-badge.live {
-  background: var(--live-soft);
-  color: var(--live);
-  border-color: rgba(22,101,52,0.2);
-}
-
-.home-path-vol-badge.syllabus {
-  background: var(--gold-soft);
-  color: var(--gold);
-  border-color: var(--gold);
-}
-
-.home-path-vol-badge.planned {
-  background: var(--surface-soft);
-  color: var(--muted);
-  border-color: var(--border);
-}
-
-.home-path-vol strong {
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1.25;
-}
-
-.home-path-vol p {
-  margin: 0;
-  font-size: 0.87rem;
-  color: var(--muted);
-  line-height: 1.5;
-}
-
-.home-path-vol-detail {
-  font-size: 0.78rem;
-  color: var(--accent);
-  font-weight: 700;
-  margin-top: 0.15rem;
-}
-
-/* ─── Struct flow (semester overview) ──────────────────────────────────────── */
-.struct-flow {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  flex-wrap: wrap;
-  margin: 0.5rem 0 0.9rem;
-}
-.struct-step {
-  display: grid;
-  gap: 0.1rem;
-  text-align: center;
-  padding: 0.55rem 0.8rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface-soft);
-  min-width: 3.8rem;
-  flex-shrink: 0;
-}
-.struct-step--active {
-  border-color: var(--hairline);
-  background: var(--accent-soft);
-}
-.struct-step--active .struct-num { color: var(--accent); }
-.struct-num { font-size: 0.85rem; font-weight: 700; color: var(--ink); line-height: 1.2; }
-.struct-label { font-size: 0.68rem; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.07em; }
-.struct-arrow { color: var(--muted); font-size: 1.1rem; flex-shrink: 0; line-height: 1; }
-.struct-note { color: var(--muted); font-size: 0.86rem; margin: 0 0 1rem; line-height: 1.65; }
-.struct-links { display: grid; gap: 0.45rem; }
-
-/* ─── Course overview cards ─────────────────────────────────────────────────── */
-.course-overview-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(195px, 1fr));
-  gap: 0.85rem;
-}
-.course-ov-card {
-  display: grid;
-  gap: 0.5rem;
-  padding: 1.25rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-  align-content: start;
-}
-.course-ov-card strong { font-size: 0.97rem; font-weight: 700; line-height: 1.3; }
-.course-ov-card p { color: var(--muted); font-size: 0.87rem; margin: 0; line-height: 1.6; }
-.course-ov-card .view-link { font-size: 0.85rem; }
-
-/* ─── Chapter list ──────────────────────────────────────────────────────────── */
-.chapter-list { display: grid; gap: 0.45rem; }
-.chapter-row {
-  display: grid;
-  grid-template-columns: 4.5rem 1fr auto;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.95rem 1.1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface);
-  text-decoration: none;
-  color: var(--ink);
-  transition: background 110ms, border-color 110ms;
-}
-.chapter-row:hover { background: var(--accent-soft); border-color: var(--hairline); }
-.chapter-row-id {
-  display: grid;
-  gap: 0.1rem;
-  padding-right: 1rem;
-  border-right: 1px solid var(--border);
-}
-.chapter-num { font-size: 1.25rem; font-weight: 700; color: var(--ink); line-height: 1; }
-.chapter-week { font-size: 0.72rem; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.chapter-row-body { display: grid; gap: 0.2rem; }
-.chapter-row-body strong { font-size: 0.93rem; font-weight: 700; }
-.chapter-row-body span { font-size: 0.82rem; color: var(--muted); line-height: 1.5; }
-.chapter-row-cta { color: var(--accent); font-size: 0.85rem; font-weight: 700; white-space: nowrap; flex-shrink: 0; }
-
-/* ─── Volume start CTA ──────────────────────────────────────────────────────── */
-.vol-start-cta {
-  margin-top: 1.25rem;
-  padding: 2.5rem 2rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-xl);
-  background: var(--surface);
-  text-align: center;
-  box-shadow: var(--shadow);
-}
-.vol-start-cta h2 { margin: 0 0 0.5rem; font-size: clamp(1.5rem, 3vw, 2rem); font-weight: 700; letter-spacing: -0.02em; }
-.vol-start-cta p { color: var(--muted); margin: 0 auto 1.35rem; max-width: 44ch; }
-
-/* ─── How It Works grid (schedule overview) ─────────────────────────────────── */
-.how-it-works-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.85rem;
-}
-.hiw-card {
-  display: grid;
-  gap: 0.4rem;
-  padding: 1.3rem 1.4rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-.hiw-card--accent {
-  background: var(--accent-soft);
-  border-color: var(--hairline);
-}
-.hiw-num {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--muted);
-}
-.hiw-card--accent .hiw-num { color: var(--accent); }
-.hiw-card strong { font-size: 0.97rem; font-weight: 700; color: var(--ink); }
-.hiw-card--accent strong { color: var(--accent); }
-.hiw-card p { margin: 0; font-size: 0.88rem; color: var(--muted); line-height: 1.7; }
-@media (max-width: 860px) { .how-it-works-grid { grid-template-columns: 1fr 1fr; } }
-@media (max-width: 540px) { .how-it-works-grid { grid-template-columns: 1fr; } }
-
-/* ─── Before You Begin — gear list ─────────────────────────────────────────── */
-.gear-list {
-  display: grid;
-  gap: 0.85rem;
-  margin-bottom: 1.5rem;
-}
-.gear-item {
-  display: grid;
-  grid-template-columns: 3rem 1fr;
-  gap: 1rem 1.25rem;
-  align-items: start;
-  padding: 1.35rem 1.5rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-.gear-item-num {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0;
-  background: var(--accent-soft);
-  border: 1px solid var(--hairline);
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: var(--accent);
-  flex-shrink: 0;
-}
-.gear-item-body { display: grid; gap: 0.35rem; }
-.gear-item-head {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  flex-wrap: wrap;
-}
-.gear-item-title {
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--ink);
-}
-.gear-type-tag {
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  padding: 0.18rem 0.5rem;
-  border-radius: 0;
-  border: 1px solid var(--border);
-  background: var(--surface-soft);
-  color: var(--muted);
-}
-.gear-type-tag.is-free {
-  background: var(--live-soft);
-  border-color: rgba(22, 101, 52, 0.2);
-  color: var(--live);
-}
-.gear-type-tag.is-habit {
-  background: var(--gold-soft);
-  border-color: var(--gold);
-  color: var(--gold);
-}
-.gear-item-body p {
-  margin: 0;
-  font-size: 0.9rem;
-  color: var(--muted);
-  line-height: 1.75;
-}
-.gear-ready-note {
-  margin: 0;
-  padding: 1rem 1.25rem;
-  background: var(--accent-soft);
-  border: 1px solid var(--hairline);
-  border-radius: var(--r-md);
-  font-size: 0.9rem;
-  color: var(--accent);
-  font-weight: 600;
-  line-height: 1.6;
-}
-.prep-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--accent);
-  text-decoration: none;
-  opacity: 0.75;
-  margin-top: 0.25rem;
-}
-.prep-link:hover { opacity: 1; text-decoration: underline; }
-
-@media (max-width: 640px) {
-  .gear-item { grid-template-columns: 2.5rem 1fr; gap: 0.75rem 1rem; padding: 1.1rem 1.1rem; }
-  .gear-item-num { width: 2.1rem; height: 2.1rem; font-size: 0.82rem; }
-}
 
 /* ─── Student work section ──────────────────────────────────────────────────── */
 .student-work {
@@ -1240,394 +329,6 @@ body > header:not(.site-header) h1 {
   border: none; border-top: 1px solid var(--hairline); margin: 0;
 }
 
-/* ─── Guide pages ───────────────────────────────────────────────────────────── */
-.guide-block {
-  display: grid;
-  grid-template-columns: 4rem 1fr;
-  gap: 1rem 2rem;
-  align-items: start;
-  padding-bottom: 2rem;
-}
-.guide-block-num {
-  font-family: 'EB Garamond', Georgia, serif;
-  font-size: 3rem;
-  font-weight: 400;
-  color: var(--accent);
-  opacity: 0.25;
-  line-height: 1;
-  padding-top: 0.2rem;
-}
-.guide-block-body { display: grid; gap: 1rem; }
-.guide-block-body h3 {
-  font-size: clamp(1.2rem, 2.5vw, 1.5rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0;
-}
-.guide-block-body p { margin: 0; color: var(--ink-soft); line-height: 1.75; }
-.guide-callout {
-  padding: 1rem 1.25rem;
-  background: var(--accent-soft);
-  border-left: 3px solid var(--accent);
-  border-radius: 0;
-  font-size: 0.9rem;
-  color: var(--accent);
-  line-height: 1.7;
-}
-.guide-callout strong { color: var(--accent); }
-
-/* guide — two-option cards (Claude vs ChatGPT) */
-.guide-options {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-.guide-option {
-  display: grid;
-  gap: 0.4rem;
-  padding: 1.25rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-.guide-option-name { font-size: 1rem; font-weight: 700; color: var(--ink); }
-.guide-option-desc { margin: 0; font-size: 0.88rem; color: var(--muted); line-height: 1.65; }
-.guide-option-url { margin: 0; font-size: 0.85rem; color: var(--ink-soft); }
-
-/* guide — numbered steps list */
-.guide-step-label { font-size: 0.85rem; font-weight: 700; color: var(--muted); text-transform: uppercase; letter-spacing: 0.07em; margin: 0; }
-.guide-steps-list {
-  margin: 0;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: 0.45rem;
-}
-.guide-steps-list li { font-size: 0.93rem; color: var(--ink-soft); line-height: 1.65; }
-
-/* guide — tip grid (2-col) */
-.guide-tip-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-.guide-tip {
-  display: grid;
-  gap: 0.3rem;
-  padding: 1.1rem 1.25rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface);
-}
-.guide-tip strong { font-size: 0.92rem; font-weight: 700; color: var(--ink); }
-.guide-tip p { margin: 0; font-size: 0.87rem; color: var(--muted); line-height: 1.65; }
-
-/* guide — platform grid (2-col) */
-.guide-platform-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.85rem;
-}
-.guide-platform {
-  display: grid;
-  gap: 0.3rem;
-  padding: 1rem 1.1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface-soft);
-}
-.guide-platform-label { font-size: 0.8rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.07em; color: var(--accent); }
-.guide-platform p { margin: 0; font-size: 0.87rem; color: var(--muted); line-height: 1.6; }
-
-/* guide — task list */
-.guide-task-list { display: grid; gap: 0.75rem; }
-.guide-task {
-  display: grid;
-  grid-template-columns: 6rem 1fr;
-  gap: 0.75rem 1rem;
-  align-items: start;
-  padding: 1rem 1.1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface);
-}
-.guide-task-label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--accent);
-  padding-top: 0.15rem;
-}
-.guide-task p { margin: 0; font-size: 0.9rem; color: var(--ink-soft); line-height: 1.7; }
-
-/* guide — habits list */
-.guide-habits {
-  margin: 0;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: 0.75rem;
-}
-.guide-habits li { font-size: 0.93rem; color: var(--ink-soft); line-height: 1.75; }
-.guide-habits li strong { color: var(--ink); }
-
-@media (max-width: 860px) {
-  .guide-block { grid-template-columns: 3rem 1fr; gap: 0.75rem 1.25rem; }
-  .guide-block-num { font-size: 2.25rem; }
-  .guide-tip-grid, .guide-options, .guide-platform-grid { grid-template-columns: 1fr; }
-}
-@media (max-width: 640px) {
-  .guide-block { grid-template-columns: 1fr; }
-  .guide-block-num { display: none; }
-  .guide-task { grid-template-columns: 4.5rem 1fr; }
-}
-
-/* ─── Library page ──────────────────────────────────────────────────────────── */
-.library-hero {
-  padding: 3.5rem 1.5rem 2.5rem;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-}
-.library-hero-copy {
-  max-width: var(--max);
-  margin: 0 auto;
-  display: grid;
-  gap: 1.5rem;
-}
-.library-hero-copy h2 {
-  font-family: 'EB Garamond', Georgia, serif;
-  font-weight: 400;
-  font-size: clamp(1.9rem, 4vw, 2.6rem);
-  line-height: 1.15;
-  margin: 0;
-}
-.library-hero-copy p {
-  color: var(--muted);
-  font-size: 1rem;
-  margin: 0;
-  max-width: 52ch;
-}
-.library-search-wrap {
-  display: grid;
-  gap: 0.75rem;
-}
-.library-search-input {
-  width: 100%;
-  padding: 0.85rem 1.1rem;
-  font-size: 1rem;
-  font-family: inherit;
-  color: var(--ink);
-  background: #fff;
-  border: 1.5px solid var(--border);
-  border-radius: var(--r-lg);
-  outline: none;
-  box-shadow: var(--shadow);
-  transition: border-color 130ms;
-  box-sizing: border-box;
-}
-.library-search-input:focus {
-  border-color: var(--hairline);
-  box-shadow: none;
-}
-.library-filter-pills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-.lib-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.35rem 0.85rem;
-  border: 1px solid var(--border);
-  border-radius: 0;
-  font-size: 0.82rem;
-  font-weight: 700;
-  font-family: inherit;
-  color: var(--muted);
-  background: var(--surface-soft);
-  cursor: pointer;
-  transition: background 110ms, border-color 110ms, color 110ms;
-}
-.lib-pill:hover {
-  background: var(--accent-soft);
-  border-color: var(--hairline);
-  color: var(--accent);
-}
-.lib-pill--active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-.library-no-results {
-  text-align: center;
-  padding: 3rem 1rem;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-.library-body {
-  max-width: var(--max);
-  margin: 0 auto;
-  padding: 2.5rem 1.5rem 5rem;
-  display: grid;
-  gap: 3rem;
-}
-.library-group {
-  display: grid;
-  gap: 1rem;
-}
-.library-group-label {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding-bottom: 0.6rem;
-  border-bottom: 1px solid var(--border);
-}
-.library-group-label h3 {
-  margin: 0;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.68rem;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--gold);
-}
-.library-group-label span {
-  font-size: 0.75rem;
-  color: var(--muted);
-  opacity: 0.7;
-}
-.lib-course-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.85rem;
-}
-.lib-card {
-  display: grid;
-  gap: 0.65rem;
-  padding: 1.25rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-  align-content: start;
-  transition: border-color 120ms, box-shadow 120ms;
-}
-.lib-card:hover {
-  border-color: var(--hairline);
-  box-shadow: var(--shadow-md);
-}
-.lib-card-head {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-.lib-code {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--accent);
-  background: var(--accent-soft);
-  border: 1px solid var(--hairline);
-  padding: 0.2rem 0.5rem;
-  border-radius: 0;
-}
-.lib-tag {
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--muted);
-  background: var(--surface-soft);
-  border: 1px solid var(--border);
-  padding: 0.18rem 0.45rem;
-  border-radius: 0;
-  margin-left: auto;
-}
-.lib-card h3 {
-  margin: 0;
-  font-size: 0.96rem;
-  font-weight: 700;
-  line-height: 1.3;
-  color: var(--ink);
-}
-.lib-card p {
-  margin: 0;
-  font-size: 0.86rem;
-  color: var(--muted);
-  line-height: 1.6;
-}
-.lib-card-topics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-.lib-topic {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--muted);
-  background: var(--surface-soft);
-  border: 1px solid var(--border);
-  padding: 0.18rem 0.5rem;
-  border-radius: 0;
-}
-.lib-card-link {
-  font-size: 0.83rem;
-  font-weight: 700;
-  color: var(--accent);
-  text-decoration: none;
-  margin-top: 0.25rem;
-}
-.lib-card-link:hover { text-decoration: underline; }
-
-/* ─── Program listing ────────────────────────────────────────────────────────── */
-.program-listing { display: grid; gap: 1.25rem; }
-.program-listing-card {
-  display: grid;
-  gap: 0.9rem;
-  padding: 1.6rem;
-  border: 1px solid var(--border);
-  border-radius: var(--r-xl);
-  background: var(--surface);
-  box-shadow: var(--shadow);
-}
-.program-listing-card--active { border-color: var(--hairline); }
-.program-listing-card--planned { background: var(--surface-soft); box-shadow: none; }
-.program-listing-card-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-}
-.program-listing-card-head h3 { margin: 0; font-size: 1.35rem; font-weight: 700; letter-spacing: -0.015em; }
-.program-listing-card-head .card-kicker { margin: 0 0 0.25rem; }
-.program-listing-card p { margin: 0; color: var(--muted); font-size: 0.93rem; line-height: 1.7; }
-.program-listing-card-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-.program-listing-card-meta span {
-  font-size: 0.78rem;
-  font-weight: 700;
-  color: var(--muted);
-  background: var(--surface-soft);
-  border: 1px solid var(--border);
-  padding: 0.25rem 0.6rem;
-  border-radius: 0;
-}
-.program-listing-card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  align-items: center;
-}
-.program-listing-coming {
-  font-size: 0.87rem;
-  color: var(--muted);
-  font-style: italic;
-}
-
 /* ─── Utility ──────────────────────────────────────────────────────────────── */
 .is-hidden { display: none !important; }
 
@@ -1636,87 +337,12 @@ body > header:not(.site-header) h1 {
   .hero.hero-split, .split-callout, .lesson-shell,
   .lesson-spotlight, .lesson-workbench { grid-template-columns: 1fr; }
   .lesson-sidebar { position: static; }
-}
-
-@media (max-width: 860px) {
-  .home-path-year { grid-template-columns: 1fr; gap: 0.75rem; }
-  .home-path-year-label { padding-top: 0; }
-  .home-path-year-label span { font-size: 0.8rem; }
-}
-
-@media (max-width: 760px) {
-  .site-header-inner { flex-direction: column; height: auto; padding: 0.75rem 1rem; gap: 0.5rem; align-items: stretch; }
-  .site-nav-toggle { display: inline-flex; }
-  .site-nav { display: none; width: 100%; grid-template-columns: 1fr; gap: 0.4rem; padding-bottom: 0.5rem; }
-  .site-header.is-nav-open .site-nav { display: grid; }
-  .site-nav a { width: 100%; justify-content: center; padding: 0.8rem; border-radius: var(--r-md); background: var(--surface-soft); border: 1px solid var(--border); }
-  .site-brand-row { width: 100%; }
-
-  main:not(.home-main) { padding: 1.5rem 1rem 4rem; }
+}@media (max-width: 760px) {
 
   .hero-copy, .hero-panel, .hero > :only-child,
   .section-panel, .lesson-content { padding: 1.25rem; }
   .hero h1, .hero h2 { font-size: clamp(1.75rem, 8vw, 2.5rem); max-width: none; }
-  .section-heading h2, .section-heading h3 { font-size: clamp(1.4rem, 6vw, 1.9rem); max-width: none; }
-  .cta-buttons, .button-row { flex-direction: column; align-items: stretch; }
   .btn, .btn.secondary, .btn.ghost { width: 100%; }
-  .directory-link { flex-direction: column; align-items: flex-start; }
-  .mini-points, .inline-list { flex-direction: column; align-items: stretch; }
-  .year-card-header { flex-direction: column; align-items: flex-start; }
-  .site-footer-inner, .program-card, .lesson-resource-grid, .lesson-practice-grid { grid-template-columns: 1fr; }
-  .metric-grid, .stat-grid { grid-template-columns: 1fr 1fr; }
-  .about-grid { grid-template-columns: 1fr; }
-
-  .home-entry { padding: 3.5rem 1.2rem 3rem; }
-  .home-entry h1 { font-size: clamp(2.2rem, 10vw, 3.4rem); }
-  .home-philosophy { padding: 3.5rem 1.2rem; }
-  .home-phi-principles { grid-template-columns: 1fr; gap: 1.75rem; }
-  .home-phi-intro h2 { font-size: clamp(1.7rem, 7vw, 2.4rem); }
-  .home-path { padding: 2.5rem 1.2rem 4rem; }
-  .home-path-volumes { grid-template-columns: 1fr; }
-
-  /* Program listing mobile */
-  .program-listing-card { padding: 1.25rem; }
-  .program-listing-card-head { flex-direction: column; gap: 0.5rem; }
-  .program-listing-card-actions { flex-direction: column; align-items: stretch; }
-  .program-listing-card-actions .btn { text-align: center; }
-
-  /* Library mobile */
-  .library-hero { padding: 2.5rem 1.2rem 2rem; }
-  .lib-course-grid { grid-template-columns: 1fr 1fr; }
-  .library-body { padding: 2rem 1.2rem 4rem; gap: 2.5rem; }
-
-  /* Chapter list / course overview mobile */
-  .chapter-row { grid-template-columns: 3.8rem 1fr auto; gap: 0.75rem; padding: 0.85rem 0.9rem; }
-  .chapter-row-id { padding-right: 0.75rem; }
-  .chapter-num { font-size: 1.05rem; }
-  .course-overview-grid { grid-template-columns: 1fr 1fr; }
-  .vol-start-cta { padding: 2rem 1.25rem; }
-  .struct-flow { gap: 0.35rem; }
-  .struct-step { padding: 0.5rem 0.65rem; min-width: 3.2rem; }
-  .struct-num { font-size: 0.78rem; }
-}
-
-@media (max-width: 640px) {
-  .feature-grid, .card-grid, .volume-grid, .cards-grid,
-  .explore-grid, .year-grid, .program-card-list { grid-template-columns: 1fr; }
-  .metric-grid, .stat-grid { grid-template-columns: 1fr 1fr; gap: 0.6rem; }
-  .site-footer-inner { grid-template-columns: 1fr; }
-  .lesson-resource-grid, .lesson-practice-grid { grid-template-columns: 1fr; }
-  .course-overview-grid { grid-template-columns: 1fr; }
-  .lib-course-grid { grid-template-columns: 1fr; }
-}
-
-@media (max-width: 480px) {
-  .site-brand-mark { width: 2rem; height: 1.85rem; }
-  .site-brand-copy strong { font-size: 0.82rem; }
-  .site-brand-copy small { font-size: 0.68rem; }
-  main:not(.home-main) { padding-inline: 0.85rem; }
-  .metric-grid, .stat-grid { grid-template-columns: 1fr; }
-  .chapter-row { grid-template-columns: 3.5rem 1fr; }
-  .chapter-row-cta { display: none; }
-  .chapter-row-body strong { font-size: 0.88rem; }
-  .chapter-row-body span { display: none; }
 }
 
 /* ════════════════════════════════════════════════════════════════════════════
@@ -1817,304 +443,10 @@ body.course-page h1 + p {
   line-height: 1.7;
 }
 
-.course-section p:last-child { margin-bottom: 0; }
-
-/* Central question */
-.course-section.is-central-q {
-  background: var(--accent-soft);
-  border-color: var(--hairline);
-}
-
-.course-section.is-central-q blockquote {
-  margin: 0;
-  padding: 0.3rem 0 0.3rem 1.1rem;
-  border-left: 3px solid var(--accent);
-  font-family: 'EB Garamond', Georgia, serif;
-  font-size: 1.25rem;
-  font-style: italic;
-  line-height: 1.45;
-  color: var(--ink);
-}
-
-.course-section.is-central-q blockquote p { margin: 0; font-size: inherit; color: inherit; }
-
-/* 15-day arc */
-.course-section.is-arc > p { margin: 0; }
-
-.course-section.is-arc strong {
-  display: block;
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--ink);
-  letter-spacing: 0.02em;
-  margin: 1rem 0 0.4rem;
-}
-
-.course-section.is-arc > p:first-of-type strong { margin-top: 0; }
-
-.course-section.is-arc ul {
-  margin: 0 0 0.2rem;
-}
-
-.course-section.is-arc li {
-  font-size: 0.88rem;
-  color: var(--muted);
-  margin-bottom: 0.15rem;
-}
-
-/* Deliverables */
-.course-section.is-deliverables li {
-  font-size: 0.93rem;
-  color: var(--ink-soft);
-}
-
-@media (max-width: 640px) {
+.course-section p:last-child { margin-bottom: 0; }@media (max-width: 640px) {
   body.course-page main { gap: 0.65rem; }
   .course-section { padding: 1.1rem 1.2rem; }
   body.course-page h1 { font-size: 1.7rem; }
-}
-
-/* ── Course day grid (on course overview pages) ─────────────────────────── */
-.course-days-section > h2 {
-  font-size: 0.68rem !important;
-  font-weight: 700 !important;
-  text-transform: uppercase !important;
-  color: var(--muted) !important;
-  letter-spacing: 0.08em !important;
-  border-bottom: 1px solid var(--border) !important;
-  padding-bottom: 0.75rem !important;
-  margin-bottom: 1rem !important;
-}
-
-.course-days-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 0.6rem;
-}
-
-.course-day-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  padding: 0.65rem 0.85rem;
-  text-decoration: none;
-  color: inherit;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.course-day-card:hover {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
-
-.course-day-num {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--ink);
-}
-
-.course-day-arrow {
-  font-size: 0.75rem;
-  color: var(--accent);
-  opacity: 0.5;
-  transition: opacity 0.15s;
-}
-
-.course-day-card:hover .course-day-arrow { opacity: 1; }
-
-@media (max-width: 700px) {
-  .course-days-grid { grid-template-columns: repeat(3, 1fr); }
-}
-
-@media (max-width: 460px) {
-  .course-days-grid { grid-template-columns: repeat(2, 1fr); }
-}
-
-/* ── Chapter index page ──────────────────────────────────────────────────── */
-body.chapter-page main {
-  max-width: var(--max);
-  display: block;
-}
-
-.chapter-eyebrow {
-  display: flex;
-  align-items: center;
-  gap: 1.25rem;
-  margin-bottom: 0.85rem;
-}
-
-.chapter-vol-label {
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  color: var(--accent);
-  letter-spacing: 0.08em;
-}
-
-.chapter-week-label {
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: var(--muted);
-  letter-spacing: 0.06em;
-}
-
-.chapter-hero {
-  padding: 2.5rem 0 2rem;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 2rem;
-}
-
-h1.chapter-title {
-  font-family: 'EB Garamond', Georgia, serif;
-  font-size: clamp(2rem, 5vw, 3rem);
-  line-height: 1.15;
-  color: var(--ink);
-  margin: 0 0 0.85rem;
-  font-weight: 400;
-}
-
-.chapter-week-num { color: var(--accent); }
-
-.chapter-intro {
-  font-size: 1.05rem;
-  color: var(--muted);
-  max-width: 640px;
-  line-height: 1.7;
-  margin: 0 0 1.75rem;
-}
-
-.chapter-stats {
-  display: flex;
-  gap: 2.5rem;
-}
-
-.chapter-stat {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-}
-
-.chapter-stat strong {
-  font-family: 'EB Garamond', Georgia, serif;
-  font-size: 1.5rem;
-  font-weight: 400;
-  color: var(--ink);
-}
-
-.chapter-stat span {
-  font-size: 0.68rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  color: var(--muted);
-  letter-spacing: 0.08em;
-}
-
-.chapter-day-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
-  margin-bottom: 2.5rem;
-}
-
-.chapter-day-card {
-  display: flex;
-  flex-direction: column;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: 1.4rem 1.25rem 1.1rem;
-  text-decoration: none;
-  color: inherit;
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.12s;
-  min-height: 150px;
-}
-
-.chapter-day-card:hover {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
-
-.chapter-day-num {
-  font-size: 0.68rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  color: var(--accent);
-  letter-spacing: 0.08em;
-  margin-bottom: 0.5rem;
-  display: block;
-}
-
-.chapter-day-title {
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: var(--ink);
-  line-height: 1.35;
-  flex: 1;
-}
-
-.chapter-day-course {
-  font-size: 0.68rem;
-  color: var(--muted);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-top: 0.65rem;
-  padding-top: 0.65rem;
-  border-top: 1px solid var(--border);
-  display: block;
-}
-
-.chapter-day-arrow {
-  font-size: 0.9rem;
-  color: var(--accent);
-  margin-top: 0.5rem;
-  opacity: 0.4;
-  transition: opacity 0.15s;
-  align-self: flex-end;
-  display: block;
-}
-
-.chapter-day-card:hover .chapter-day-arrow { opacity: 1; }
-
-.chapter-nav {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.5rem 0;
-  border-top: 1px solid var(--border);
-}
-
-.chapter-nav a {
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--accent);
-  text-decoration: none;
-}
-
-.chapter-nav a:hover { text-decoration: underline; }
-
-.chapter-nav-schedule {
-  margin: 0 auto;
-  color: var(--muted) !important;
-  font-weight: 600 !important;
-}
-
-@media (max-width: 900px) {
-  .chapter-day-grid { grid-template-columns: repeat(3, 1fr); }
-}
-
-@media (max-width: 600px) {
-  .chapter-day-grid { grid-template-columns: 1fr 1fr; }
-  .chapter-stats { gap: 1.5rem; }
-  .chapter-hero { padding: 1.5rem 0 1.5rem; }
-}
-
-@media (max-width: 420px) {
-  .chapter-day-grid { grid-template-columns: 1fr; }
 }
 
 /* ─── Student response fields ─────────────────────────────────────────────── */
@@ -2206,39 +538,6 @@ main a.is-visited::after {
   letter-spacing: 0.02em;
   color: var(--muted);
   margin: 0 0 1rem;
-}
-.lesson-week-label {
-  font-size: 0.8rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  margin: 0 0 0.5rem;
-}
-.lesson-week-map {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-bottom: 1.25rem;
-}
-.lesson-week-pill {
-  font-size: 0.8rem;
-  padding: 0.3rem 0.7rem;
-  border: 1px solid var(--border);
-  border-radius: 0;
-  color: var(--muted);
-  text-decoration: none;
-  transition: border-color 150ms, color 150ms;
-}
-a.lesson-week-pill:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.lesson-week-pill.is-current {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-  font-weight: 600;
 }
 .lesson-tomorrow-card {
   display: block;
@@ -2468,9 +767,6 @@ main a.is-visited::after {
   font-weight: 700;
   color: var(--accent, #234E70);
 }
-a.lesson-week-pill.is-visited::after {
-  margin-left: 0.3em;
-}
 .home-cta-sub {
   margin-top: 0.85rem;
   font-size: 0.9rem;
@@ -2480,68 +776,6 @@ a.lesson-week-pill.is-visited::after {
   color: inherit;
   text-decoration: underline;
 }
-
-/* ── The Daily (newsletter issues + archive) ────────────────────────────── */
-
-.daily-masthead {
-  font-size: 0.78rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--accent, #234E70);
-  margin: 0 0 0.5rem;
-}
-.daily-subscribe {
-  margin: 2.5rem 0;
-  padding: 1.25rem 1.5rem;
-  border: 1px solid var(--border, rgba(17, 19, 24, 0.1));
-  border-left: 3px solid var(--accent, #234E70);
-  border-radius: 12px;
-  background: var(--accent-soft, rgba(35, 78, 112, 0.06));
-}
-.daily-subscribe strong { display: block; margin-bottom: 0.3rem; }
-.daily-subscribe p { margin: 0; font-size: 0.92rem; color: var(--muted, #6b7280); }
-.daily-issue-footer {
-  margin-top: 3rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--border, rgba(17, 19, 24, 0.1));
-  font-size: 0.92rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-}
-.daily-archive {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 3rem;
-}
-.daily-card {
-  display: block;
-  padding: 1.15rem 1.3rem;
-  border: 1px solid var(--border, rgba(17, 19, 24, 0.1));
-  border-radius: 12px;
-  text-decoration: none;
-  color: inherit;
-  transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
-}
-.daily-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 18px rgba(17, 19, 24, 0.08);
-  border-color: var(--accent, #234E70);
-  text-decoration: none;
-}
-.daily-card-meta {
-  display: block;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--accent, #234E70);
-  margin-bottom: 0.3rem;
-}
-.daily-card strong { display: block; font-size: 1.08rem; line-height: 1.35; }
-.daily-card p { margin: 0.4rem 0 0; font-size: 0.88rem; color: var(--muted, #6b7280); }
 
 /* ================================================================
    CHARTER DESIGN SYSTEM — ported from sandiegotech.org
@@ -2642,9 +876,7 @@ body.charter-page main {
 }
 .hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
 .hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
-
-@media (max-width: 800px) {
+.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }@media (max-width: 800px) {
   .masthead-inner,
   .masthead--learn .masthead-inner {
     flex-wrap: wrap;
@@ -2713,21 +945,6 @@ body.charter-page main {
 
 .charter .standfirst + .standfirst { margin-top: 1.1rem; }
 
-.meridian {
-  margin-top: 3.5rem;
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-.meridian svg { flex: none; }
-.meridian .coords {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  color: var(--muted);
-}
-.meridian .line { flex: 1; height: 1px; background: var(--hairline); }
-
 .rise {
   opacity: 0;
   transform: translateY(10px);
@@ -2736,8 +953,7 @@ body.charter-page main {
 .rise.d1 { animation-delay: 0.12s; }
 .rise.d2 { animation-delay: 0.24s; }
 .rise.d3 { animation-delay: 0.36s; }
-@keyframes rise { to { opacity: 1; transform: none; } }
-@media (prefers-reduced-motion: reduce) {
+@keyframes rise { to { opacity: 1; transform: none; } }@media (prefers-reduced-motion: reduce) {
   .rise { animation: none !important; opacity: 1 !important; transform: none !important; }
 }
 
@@ -2751,14 +967,10 @@ body.charter-page main {
   display: grid;
   grid-template-columns: 14rem minmax(0, 1fr);
   gap: 3rem;
-}
-
-@media (max-width: 860px) {
+}@media (max-width: 860px) {
   .article-grid { grid-template-columns: 1fr; gap: 1.5rem; }
   .charter { padding: 4rem 0 3.5rem; }
-}
-
-@media (max-width: 640px) {
+}@media (max-width: 640px) {
   .article { padding: 3rem 0; }
   .page-header { padding: 3.25rem 0 2.5rem; }
 }
@@ -2823,9 +1035,7 @@ body.charter-page main {
   gap: 1.5rem;
   padding: 1.15rem 0;
   border-bottom: 1px solid var(--hairline);
-}
-
-@media (max-width: 540px) {
+}@media (max-width: 540px) {
   .triad-row { grid-template-columns: 1fr; gap: 0.35rem; }
 }
 
@@ -2885,21 +1095,8 @@ body.charter-page main {
   white-space: nowrap;
 }
 
-.ledger a:hover .l-meta { color: var(--gold); }
-
-@media (max-width: 540px) {
+.ledger a:hover .l-meta { color: var(--gold); }@media (max-width: 540px) {
   .ledger .l-meta { white-space: normal; }
-}
-
-.motion-head {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--gold);
-  margin-top: 2.25rem;
-  margin-bottom: 0;
 }
 
 .cta {
@@ -3038,9 +1235,7 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   text-transform: uppercase;
   color: var(--marine);
   margin-top: 1.25rem;
-}
-
-@media (max-width: 680px) {
+}@media (max-width: 680px) {
   .join-paths, .join-paths--3 { grid-template-columns: 1fr; }
 }
 
@@ -3126,7 +1321,6 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   margin: 0;
   font-size: 0.92rem;
 }
-.sem-courses .c-code { font-family: var(--font-mono); font-size: 0.76rem; color: var(--marine); padding-top: 0.1rem; }
 .sem-courses .c-name { color: var(--ink); }
 .sem-courses .c-name em { color: var(--muted); font-style: italic; }
 .sem-milestone {
@@ -3136,8 +1330,7 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--gold);
-}
-@media (max-width: 540px) {
+}@media (max-width: 540px) {
   .sem-courses li { grid-template-columns: 1fr; gap: 0.1rem; }
 }
 
@@ -3158,9 +1351,7 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   color: var(--gold);
   padding-top: 0.2rem;
 }
-.rhythm-row p { margin: 0; font-size: 0.95rem; color: var(--ink); }
-.rhythm-row p .r-note { color: var(--muted); }
-@media (max-width: 540px) {
+.rhythm-row p { margin: 0; font-size: 0.95rem; color: var(--ink); }@media (max-width: 540px) {
   .rhythm-row { grid-template-columns: 1fr; gap: 0.3rem; }
 }
 
@@ -3171,8 +1362,7 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.masthead .toc a.toc-resume:hover { color: var(--ink); }
-@media (max-width: 880px) and (min-width: 801px) {
+.masthead .toc a.toc-resume:hover { color: var(--ink); }@media (max-width: 880px) and (min-width: 801px) {
   .masthead .toc a.toc-resume { display: none; }
 }
 
@@ -3202,159 +1392,6 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   z-index: 100;
   background: var(--ink);
   border-bottom: 2px solid var(--gold);
-}
-
-.learn-head-inner {
-  max-width: 72rem;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  min-height: 3.6rem;
-  display: flex;
-  align-items: center;
-  gap: 1.75rem;
-}
-
-.learn-brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.7rem;
-  text-decoration: none;
-  flex-shrink: 0;
-  padding: 0.5rem 0;
-}
-.learn-brand img { height: 1.7rem; width: auto; display: block; }
-.learn-brand-text { display: grid; line-height: 1.25; }
-.learn-brand-text strong {
-  font-family: var(--font-display);
-  font-size: 1.12rem;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  color: #FCFBF8;
-}
-.learn-brand-text small {
-  font-family: var(--font-body);
-  font-size: 0.62rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(252, 251, 248, 0.55);
-}
-
-.learn-nav {
-  display: flex;
-  align-items: center;
-  gap: 1.4rem;
-  margin-left: 0.5rem;
-}
-.learn-nav a {
-  font-family: var(--font-body);
-  font-size: 0.92rem;
-  font-weight: 500;
-  color: rgba(252, 251, 248, 0.72);
-  text-decoration: none;
-  padding: 1.05rem 0;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -2px; /* sit on the gold rule */
-  transition: color 0.15s ease, border-color 0.15s ease;
-}
-.learn-nav a:hover { color: #FCFBF8; }
-.learn-nav a[aria-current="page"] {
-  color: var(--gold-bright, #D4B968);
-  color: #D4B968;
-  border-bottom-color: #D4B968;
-}
-
-.learn-actions {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  min-width: 0;
-}
-
-.learn-actions a.learn-resume {
-  display: inline-block;
-  font-family: var(--font-body);
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--ink);
-  background: #D4B968;
-  padding: 0.38rem 0.85rem;
-  border-radius: 999px;
-  text-decoration: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 17rem;
-  transition: background 0.15s ease;
-}
-.learn-actions a.learn-resume:hover { background: #E5CD85; }
-
-.learn-actions a.learn-institute {
-  font-family: var(--font-body);
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: rgba(252, 251, 248, 0.6);
-  text-decoration: none;
-  white-space: nowrap;
-  transition: color 0.15s ease;
-}
-.learn-actions a.learn-institute:hover { color: #FCFBF8; }
-
-.learn-toggle {
-  display: none;
-  flex-direction: column;
-  gap: 5px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0.4rem;
-  margin-left: auto;
-}
-.learn-toggle span {
-  display: block;
-  width: 21px;
-  height: 2px;
-  background: rgba(252, 251, 248, 0.85);
-  transition: transform 0.2s ease, opacity 0.15s ease;
-}
-.learn-toggle[aria-expanded="true"] span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
-.learn-toggle[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
-.learn-toggle[aria-expanded="true"] span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
-
-@media (max-width: 980px) {
-  .learn-actions a.learn-resume { max-width: 11rem; }
-  .learn-nav { gap: 1.1rem; }
-}
-
-@media (max-width: 800px) {
-  .learn-head-inner { flex-wrap: wrap; gap: 0 1rem; }
-  .learn-toggle { display: flex; }
-  .learn-nav, .learn-actions {
-    display: none;
-    width: 100%;
-  }
-  .learn-head.is-open .learn-nav,
-  .learn-head.is-open .learn-actions {
-    display: flex;
-  }
-  .learn-head.is-open .learn-nav {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0;
-    margin-left: 0;
-    padding-top: 0.25rem;
-  }
-  .learn-head.is-open .learn-nav a {
-    padding: 0.8rem 0.25rem;
-    margin-bottom: 0;
-    border-bottom: 1px solid rgba(252, 251, 248, 0.12);
-  }
-  .learn-head.is-open .learn-nav a[aria-current="page"] { border-bottom-color: rgba(252, 251, 248, 0.12); }
-  .learn-head.is-open .learn-actions {
-    padding: 0.9rem 0.25rem 1.1rem;
-    justify-content: space-between;
-  }
-  .learn-actions a.learn-resume { max-width: 100%; }
 }
 
 /* ================================================================
@@ -3392,8 +1429,7 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
 .day-figure img { max-height: 76vh; object-fit: contain; background: var(--surface-soft); }
 
 /* Download ledger meta stays readable */
-.ledger .l-meta { max-width: 14rem; text-align: right; white-space: normal; }
-@media (max-width: 540px) {
+.ledger .l-meta { max-width: 14rem; text-align: right; white-space: normal; }@media (max-width: 540px) {
   .ledger a { grid-template-columns: 1fr; }
   .ledger .l-meta { text-align: left; max-width: none; }
 }
@@ -3429,12 +1465,9 @@ a.join-path:hover { border-color: var(--gold); background: var(--gold-dim); }
   text-overflow: ellipsis;
   vertical-align: middle;
 }
-.masthead .toc a.toc-resume:hover { color: var(--gold); border-color: var(--gold); }
-
-@media (max-width: 1020px) and (min-width: 681px) {
+.masthead .toc a.toc-resume:hover { color: var(--gold); border-color: var(--gold); }@media (max-width: 1020px) and (min-width: 681px) {
   .masthead .toc a.toc-resume { max-width: 9rem; }
-}
-@media (max-width: 800px) {
+}@media (max-width: 800px) {
   .masthead .toc a.toc-resume { max-width: 100%; border: none; background: none; padding: 0.55rem 0; color: var(--gold); }
 }
 
@@ -3539,9 +1572,7 @@ a.door--wide {
 }
 a.door--wide .door-title { font-size: 1.45rem; margin: 0; }
 a.door--wide .door-desc { margin: 0; }
-a.door--wide .door-go { white-space: nowrap; }
-
-@media (max-width: 720px) {
+a.door--wide .door-go { white-space: nowrap; }@media (max-width: 720px) {
   .start-doors { grid-template-columns: 1fr; }
   a.door { padding: 1.8rem 1.5rem 1.5rem; }
   a.door--wide { flex-direction: column; gap: 0.5rem; padding: 1.5rem; }
@@ -3586,8 +1617,7 @@ a.door--wide .door-go { white-space: nowrap; }
   color: var(--ink);
   margin-bottom: 0.25rem;
 }
-.start-how span { font-size: 0.88rem; color: var(--muted); line-height: 1.5; }
-@media (max-width: 640px) {
+.start-how span { font-size: 0.88rem; color: var(--muted); line-height: 1.5; }@media (max-width: 640px) {
   .start-how { grid-template-columns: 1fr; gap: 1.4rem; }
 }
 
@@ -3622,7 +1652,6 @@ a.door--wide .door-go { white-space: nowrap; }
 
 /* door internals always stack */
 a.door .door-kicker, a.door .door-title, a.door .door-desc { display: block; }
-
 
 
 /* ── Masthead refinements: gold crest sized to the two-line wordmark,

--- a/courses/CS-110/index.html
+++ b/courses/CS-110/index.html
@@ -14,40 +14,71 @@
   <div data-include="/partials/header.html"></div>
   <main>
   <h1 id="cs-110-programming-fundamentals">CS 110 — Programming Fundamentals</h1>
-<p><strong>Computation &amp; Intelligent Systems</strong> · 4 units · Required core — everyone takes it</p>
+<p><strong>Computation &amp; Intelligent Systems</strong> · 4 units · Semester 1 · Required core — everyone takes it</p>
+<h2 id="overview">Overview</h2>
+<p>Code is the most literal language ever invented — the machine does exactly what you say, which is how you find out what you actually said. This course is your first sustained conversation with that very fast, very literal apprentice: variables, control flow, functions, data, debugging — the moves every program is made of.</p>
+<p>Taught <strong>AI-native from the first hour</strong>. The tools stay open on the table — instrumented, critiqued, never hidden — because pretending they don&rsquo;t exist would be training you for a world that&rsquo;s gone. The skill this course actually grades is <strong>direction and verification</strong>: telling the machine precisely what you want, and proving to yourself that what came back is right. That second skill is the one that survives every model release.</p>
+<p>One day a week, about ten minutes a sitting, hands on the keys from Day 1, building toward a small program that does something you genuinely wanted done.</p>
 <h2 id="the-two-registers">The Two Registers</h2>
 <ul>
-<li><strong>Catalog register:</strong> Introduction to programming — variables, control flow, functions, data, debugging.</li>
-<li><strong>Teaching frame:</strong> AI tools open, instrumented, and critiqued from day one. The skill is direction and verification.</li>
+<li><strong>Catalog register:</strong> Introduction to programming — variables, control flow, functions, data structures, debugging. Transfer-legible CS1.</li>
+<li><strong>Teaching frame:</strong> Speaking to Machines — AI tools open, instrumented, and critiqued from day one. The graded skill is direction and verification.</li>
 </ul>
-<h2 id="outcomes-served">Outcomes Served</h2>
-<ul>
-<li><strong>Command of Intelligence</strong></li>
-<li><strong>Craft</strong></li>
-</ul>
-<h2 id="what-this-course-is-about">What This Course Is About</h2>
-<p>Code is the most literal language ever invented — the machine does exactly what you say, which is how you find out what you actually said. Taught AI-native from the first hour: the tools stay open, and the skill graded is direction and verification.</p>
+<h2 id="learning-outcomes">Learning Outcomes</h2>
+<p>By the end of this course you can:</p>
+<ol>
+<li>Write, run, and debug programs using variables, control flow, functions, and basic data structures. → <em>Craft</em></li>
+<li>Decompose a real problem into steps a machine can execute, and explain the decomposition. → <em>Judgment</em></li>
+<li>Direct AI tools to produce code — and verify, test, and correct what comes back. → <em>Command of Intelligence</em></li>
+<li>Explain any line of your program, unassisted, out loud or in writing. → <em>Articulation · Command of Intelligence</em></li>
+<li>Ship a small working program and document what it does and why. → <em>Craft</em></li>
+</ol>
+<p><em>Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.</em></p>
 <h2 id="the-made-thing">The Made Thing</h2>
-<p>A small working program that does something you actually wanted done — written with AI in the loop and verified without it.</p>
-<h2 id="the-daily-path">The Daily Path</h2>
-<p>One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.</p>
+<p>A small working program that does something you actually wanted done — written with AI in the loop and verified without it, shipped with a short write-up of what it does and how you know it works.</p>
+<h2 id="how-youre-assessed">How You&rsquo;re Assessed</h2>
 <ul>
-<li><a href="day-01.html">Day 01 — The Very Fast, Very Literal Apprentice</a></li>
-<li>Day 02 — <em>to be written</em></li>
-<li>Day 03 — <em>to be written</em></li>
-<li>Day 04 — <em>to be written</em></li>
-<li>Day 05 — <em>to be written</em></li>
-<li>Day 06 — <em>to be written</em></li>
-<li>Day 07 — <em>to be written</em></li>
-<li>Day 08 — <em>to be written</em></li>
-<li>Day 09 — <em>to be written</em></li>
-<li>Day 10 — <em>to be written</em></li>
-<li>Day 11 — <em>to be written</em></li>
-<li>Day 12 — <em>to be written</em></li>
-<li>Day 13 — <em>to be written</em></li>
-<li>Day 14 — <em>to be written</em></li>
-<li>Day 15 — <em>to be written</em></li>
+<li><strong>Weekly builds</strong> — small programs, graded on whether they work and whether you can explain them.</li>
+<li><strong>The shipped program</strong>, demonstrated and defended.</li>
+<li><strong>Unassisted examinations in code</strong> — reading, writing, and debugging with the tools closed. The institution certifies the human.</li>
+<li>Everything lands in your <strong>portfolio</strong>, reviewed against the five outcomes at the end-of-year gate.</li>
 </ul>
+<h2 id="the-daily-path">The Daily Path</h2>
+<p>One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course&rsquo;s own day files.</p>
+<!-- sdit:days:begin -->
+<h3 id="day-01-the-very-fast-very-literal-apprentice">Day 01 — The Very Fast, Very Literal Apprentice</h3>
+<p>Ten minutes. One machine made of junk, one idea, one question. You will not install anything today.</p>
+<p><a href="day-01.html">Begin Day 01 →</a></p>
+<h3 id="day-02-coming-soon">Day 02 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 2. All five courses advance together, week by week.</p>
+<h3 id="day-03-coming-soon">Day 03 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 3. All five courses advance together, week by week.</p>
+<h3 id="day-04-coming-soon">Day 04 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 4. All five courses advance together, week by week.</p>
+<h3 id="day-05-coming-soon">Day 05 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 5. All five courses advance together, week by week.</p>
+<h3 id="day-06-coming-soon">Day 06 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 6. All five courses advance together, week by week.</p>
+<h3 id="day-07-coming-soon">Day 07 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 7. All five courses advance together, week by week.</p>
+<h3 id="day-08-coming-soon">Day 08 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 8. All five courses advance together, week by week.</p>
+<h3 id="day-09-coming-soon">Day 09 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 9. All five courses advance together, week by week.</p>
+<h3 id="day-10-coming-soon">Day 10 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 10. All five courses advance together, week by week.</p>
+<h3 id="day-11-coming-soon">Day 11 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 11. All five courses advance together, week by week.</p>
+<h3 id="day-12-coming-soon">Day 12 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 12. All five courses advance together, week by week.</p>
+<h3 id="day-13-coming-soon">Day 13 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 13. All five courses advance together, week by week.</p>
+<h3 id="day-14-coming-soon">Day 14 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 14. All five courses advance together, week by week.</p>
+<h3 id="day-15-coming-soon">Day 15 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 15. All five courses advance together, week by week.</p>
+<!-- sdit:days:end -->
+
 <hr />
 <p><em>Every course here is built to one standard: it ends in a made thing you can show, and it ships day by day.</em></p>
   </main>

--- a/courses/CS-110/index.md
+++ b/courses/CS-110/index.md
@@ -4,50 +4,117 @@ title: "CS 110 — Programming Fundamentals"
 course_code: CS 110
 units: 4
 thread: Computation & Intelligent Systems
+semester: 1
 status: day1
 ---
 
 # CS 110 — Programming Fundamentals
 
-**Computation & Intelligent Systems** · 4 units · Required core — everyone takes it
+**Computation & Intelligent Systems** · 4 units · Semester 1 · Required core — everyone takes it
+
+## Overview
+
+Code is the most literal language ever invented — the machine does exactly what you say, which is how you find out what you actually said. This course is your first sustained conversation with that very fast, very literal apprentice: variables, control flow, functions, data, debugging — the moves every program is made of.
+
+Taught **AI-native from the first hour**. The tools stay open on the table — instrumented, critiqued, never hidden — because pretending they don't exist would be training you for a world that's gone. The skill this course actually grades is **direction and verification**: telling the machine precisely what you want, and proving to yourself that what came back is right. That second skill is the one that survives every model release.
+
+One day a week, about ten minutes a sitting, hands on the keys from Day 1, building toward a small program that does something you genuinely wanted done.
 
 ## The Two Registers
 
-- **Catalog register:** Introduction to programming — variables, control flow, functions, data, debugging.
-- **Teaching frame:** AI tools open, instrumented, and critiqued from day one. The skill is direction and verification.
+- **Catalog register:** Introduction to programming — variables, control flow, functions, data structures, debugging. Transfer-legible CS1.
+- **Teaching frame:** Speaking to Machines — AI tools open, instrumented, and critiqued from day one. The graded skill is direction and verification.
 
-## Outcomes Served
+## Learning Outcomes
 
-- **Command of Intelligence**
-- **Craft**
+By the end of this course you can:
 
-## What This Course Is About
+1. Write, run, and debug programs using variables, control flow, functions, and basic data structures. → *Craft*
+2. Decompose a real problem into steps a machine can execute, and explain the decomposition. → *Judgment*
+3. Direct AI tools to produce code — and verify, test, and correct what comes back. → *Command of Intelligence*
+4. Explain any line of your program, unassisted, out loud or in writing. → *Articulation · Command of Intelligence*
+5. Ship a small working program and document what it does and why. → *Craft*
 
-Code is the most literal language ever invented — the machine does exactly what you say, which is how you find out what you actually said. Taught AI-native from the first hour: the tools stay open, and the skill graded is direction and verification.
+*Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.*
 
 ## The Made Thing
 
-A small working program that does something you actually wanted done — written with AI in the loop and verified without it.
+A small working program that does something you actually wanted done — written with AI in the loop and verified without it, shipped with a short write-up of what it does and how you know it works.
+
+## How You're Assessed
+
+- **Weekly builds** — small programs, graded on whether they work and whether you can explain them.
+- **The shipped program**, demonstrated and defended.
+- **Unassisted examinations in code** — reading, writing, and debugging with the tools closed. The institution certifies the human.
+- Everything lands in your **portfolio**, reviewed against the five outcomes at the end-of-year gate.
 
 ## The Daily Path
 
-One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.
+One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course's own day files.
 
-- [Day 01 — The Very Fast, Very Literal Apprentice](day-01.html)
-- Day 02 — *to be written*
-- Day 03 — *to be written*
-- Day 04 — *to be written*
-- Day 05 — *to be written*
-- Day 06 — *to be written*
-- Day 07 — *to be written*
-- Day 08 — *to be written*
-- Day 09 — *to be written*
-- Day 10 — *to be written*
-- Day 11 — *to be written*
-- Day 12 — *to be written*
-- Day 13 — *to be written*
-- Day 14 — *to be written*
-- Day 15 — *to be written*
+<!-- sdit:days:begin -->
+### Day 01 — The Very Fast, Very Literal Apprentice
+
+Ten minutes. One machine made of junk, one idea, one question. You will not install anything today.
+
+[Begin Day 01 →](day-01.html)
+
+### Day 02 — *coming soon*
+
+Being written — publishes with Week 2. All five courses advance together, week by week.
+
+### Day 03 — *coming soon*
+
+Being written — publishes with Week 3. All five courses advance together, week by week.
+
+### Day 04 — *coming soon*
+
+Being written — publishes with Week 4. All five courses advance together, week by week.
+
+### Day 05 — *coming soon*
+
+Being written — publishes with Week 5. All five courses advance together, week by week.
+
+### Day 06 — *coming soon*
+
+Being written — publishes with Week 6. All five courses advance together, week by week.
+
+### Day 07 — *coming soon*
+
+Being written — publishes with Week 7. All five courses advance together, week by week.
+
+### Day 08 — *coming soon*
+
+Being written — publishes with Week 8. All five courses advance together, week by week.
+
+### Day 09 — *coming soon*
+
+Being written — publishes with Week 9. All five courses advance together, week by week.
+
+### Day 10 — *coming soon*
+
+Being written — publishes with Week 10. All five courses advance together, week by week.
+
+### Day 11 — *coming soon*
+
+Being written — publishes with Week 11. All five courses advance together, week by week.
+
+### Day 12 — *coming soon*
+
+Being written — publishes with Week 12. All five courses advance together, week by week.
+
+### Day 13 — *coming soon*
+
+Being written — publishes with Week 13. All five courses advance together, week by week.
+
+### Day 14 — *coming soon*
+
+Being written — publishes with Week 14. All five courses advance together, week by week.
+
+### Day 15 — *coming soon*
+
+Being written — publishes with Week 15. All five courses advance together, week by week.
+<!-- sdit:days:end -->
 
 ---
 

--- a/courses/HUM-101/index.html
+++ b/courses/HUM-101/index.html
@@ -14,41 +14,70 @@
   <div data-include="/partials/header.html"></div>
   <main>
   <h1 id="hum-101-the-ancient-world">HUM 101 — The Ancient World</h1>
-<p><strong>The Canon</strong> · 2 units · Required core — everyone takes it</p>
+<p><strong>The Canon</strong> · 2 units · Semester 1 · Required core — everyone takes it</p>
+<h2 id="overview">Overview</h2>
+<p>The oldest stories we have are survival manuals for being human, and they are still about you. Fifteen weeks inside Homer, the tragedians, Thucydides, and Plato — and none of it read alone. This is the Double Feature Method: every unit pairs <strong>the text + a film + an album</strong>, discussed as one conversation, so the argument crosses three thousand years without slowing down. <em>The Odyssey</em> beside The Endless Summer; <em>The Republic</em> beside The Matrix.</p>
+<p>This is how the Canon works at SDIT: not literature appreciation, but a working toolkit. Odysseus engineering his way past the Sirens is systems thinking about human weakness, three millennia before anyone called it that. You read these books because the people who build the things you admire read them — and because every day of this course hands you a question you will actually use.</p>
+<p>One day a week, about ten minutes a sitting, plus the reading that pulls you in. The course ends the way every SDIT course ends: in a made thing, defended out loud.</p>
 <h2 id="the-two-registers">The Two Registers</h2>
 <ul>
-<li><strong>Catalog register:</strong> Survey of ancient Mediterranean literature and philosophy — Homer, the tragedians, Thucydides, Plato.</li>
-<li><strong>Teaching frame:</strong> The Double Feature — The Odyssey + The Endless Summer; Republic + The Matrix. The text, a film, and an album, discussed as one conversation.</li>
+<li><strong>Catalog register:</strong> Survey of ancient Mediterranean literature and philosophy — Homer, the tragedians, Thucydides, Plato. Close reading, discussion, and critical writing.</li>
+<li><strong>Teaching frame:</strong> The Double Feature — the text, a film, and an album, discussed as one conversation. The ancient question carried into the present decision.</li>
 </ul>
-<h2 id="outcomes-served">Outcomes Served</h2>
-<ul>
-<li><strong>Judgment</strong></li>
-<li><strong>Articulation</strong></li>
-<li><strong>Breadth of Mind</strong></li>
-</ul>
-<h2 id="what-this-course-is-about">What This Course Is About</h2>
-<p>The oldest stories we have are survival manuals for being human, and they are still about you. Eight weeks inside Homer, the tragedians, and Plato — each unit paired with a film and an album so the conversation crosses three thousand years without slowing down.</p>
+<h2 id="learning-outcomes">Learning Outcomes</h2>
+<p>By the end of this course you can:</p>
+<ol>
+<li>Read an ancient primary text closely and accurately reconstruct its central argument. → <em>Breadth of Mind</em></li>
+<li>Trace one idea across a text, a film, and an album, and defend the connection with evidence from all three. → <em>Judgment</em></li>
+<li>Write short critical responses that make a claim, support it from the text, and survive line-editing. → <em>Articulation</em></li>
+<li>Produce a made response — essay, short film, recorded piece, or designed object — and defend it in seminar. → <em>Craft · Articulation</em></li>
+</ol>
+<p><em>Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.</em></p>
 <h2 id="the-made-thing">The Made Thing</h2>
-<p>A made response — essay, short film, recorded piece, or designed object — defended in seminar.</p>
-<h2 id="the-daily-path">The Daily Path</h2>
-<p>One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.</p>
+<p>A made response to the ancient world — an essay, a short film, a recorded piece, or a designed object — defended in seminar. It enters your portfolio and is reviewed at the annual gate.</p>
+<h2 id="how-youre-assessed">How You&rsquo;re Assessed</h2>
 <ul>
-<li><a href="day-01.html">Day 01 — The Oldest Story Is About You</a></li>
-<li>Day 02 — <em>to be written</em></li>
-<li>Day 03 — <em>to be written</em></li>
-<li>Day 04 — <em>to be written</em></li>
-<li>Day 05 — <em>to be written</em></li>
-<li>Day 06 — <em>to be written</em></li>
-<li>Day 07 — <em>to be written</em></li>
-<li>Day 08 — <em>to be written</em></li>
-<li>Day 09 — <em>to be written</em></li>
-<li>Day 10 — <em>to be written</em></li>
-<li>Day 11 — <em>to be written</em></li>
-<li>Day 12 — <em>to be written</em></li>
-<li>Day 13 — <em>to be written</em></li>
-<li>Day 14 — <em>to be written</em></li>
-<li>Day 15 — <em>to be written</em></li>
+<li><strong>Short written responses</strong>, line-edited and revised — the work is the writing, not a quiz about the reading.</li>
+<li><strong>The made response</strong>, defended out loud in seminar at the end of the course.</li>
+<li><strong>Periodic unassisted writing.</strong> AI tools are open for drafting and study; the institution certifies the human, so part of your writing happens with the tools closed.</li>
+<li>Everything lands in your <strong>portfolio</strong>, reviewed against the five outcomes at the end-of-year gate.</li>
 </ul>
+<h2 id="the-daily-path">The Daily Path</h2>
+<p>One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course&rsquo;s own day files.</p>
+<!-- sdit:days:begin -->
+<h3 id="day-01-the-oldest-story-is-about-you">Day 01 — The Oldest Story Is About You</h3>
+<p>Ten minutes. One painted cup, eight lines of poetry, one question.</p>
+<p><a href="day-01.html">Begin Day 01 →</a></p>
+<h3 id="day-02-coming-soon">Day 02 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 2. All five courses advance together, week by week.</p>
+<h3 id="day-03-coming-soon">Day 03 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 3. All five courses advance together, week by week.</p>
+<h3 id="day-04-coming-soon">Day 04 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 4. All five courses advance together, week by week.</p>
+<h3 id="day-05-coming-soon">Day 05 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 5. All five courses advance together, week by week.</p>
+<h3 id="day-06-coming-soon">Day 06 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 6. All five courses advance together, week by week.</p>
+<h3 id="day-07-coming-soon">Day 07 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 7. All five courses advance together, week by week.</p>
+<h3 id="day-08-coming-soon">Day 08 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 8. All five courses advance together, week by week.</p>
+<h3 id="day-09-coming-soon">Day 09 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 9. All five courses advance together, week by week.</p>
+<h3 id="day-10-coming-soon">Day 10 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 10. All five courses advance together, week by week.</p>
+<h3 id="day-11-coming-soon">Day 11 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 11. All five courses advance together, week by week.</p>
+<h3 id="day-12-coming-soon">Day 12 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 12. All five courses advance together, week by week.</p>
+<h3 id="day-13-coming-soon">Day 13 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 13. All five courses advance together, week by week.</p>
+<h3 id="day-14-coming-soon">Day 14 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 14. All five courses advance together, week by week.</p>
+<h3 id="day-15-coming-soon">Day 15 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 15. All five courses advance together, week by week.</p>
+<!-- sdit:days:end -->
+
 <hr />
 <p><em>Every course here is built to one standard: it ends in a made thing you can show, and it ships day by day.</em></p>
   </main>

--- a/courses/HUM-101/index.md
+++ b/courses/HUM-101/index.md
@@ -4,51 +4,116 @@ title: "HUM 101 — The Ancient World"
 course_code: HUM 101
 units: 2
 thread: The Canon
+semester: 1
 status: day1
 ---
 
 # HUM 101 — The Ancient World
 
-**The Canon** · 2 units · Required core — everyone takes it
+**The Canon** · 2 units · Semester 1 · Required core — everyone takes it
+
+## Overview
+
+The oldest stories we have are survival manuals for being human, and they are still about you. Fifteen weeks inside Homer, the tragedians, Thucydides, and Plato — and none of it read alone. This is the Double Feature Method: every unit pairs **the text + a film + an album**, discussed as one conversation, so the argument crosses three thousand years without slowing down. *The Odyssey* beside The Endless Summer; *The Republic* beside The Matrix.
+
+This is how the Canon works at SDIT: not literature appreciation, but a working toolkit. Odysseus engineering his way past the Sirens is systems thinking about human weakness, three millennia before anyone called it that. You read these books because the people who build the things you admire read them — and because every day of this course hands you a question you will actually use.
+
+One day a week, about ten minutes a sitting, plus the reading that pulls you in. The course ends the way every SDIT course ends: in a made thing, defended out loud.
 
 ## The Two Registers
 
-- **Catalog register:** Survey of ancient Mediterranean literature and philosophy — Homer, the tragedians, Thucydides, Plato.
-- **Teaching frame:** The Double Feature — The Odyssey + The Endless Summer; Republic + The Matrix. The text, a film, and an album, discussed as one conversation.
+- **Catalog register:** Survey of ancient Mediterranean literature and philosophy — Homer, the tragedians, Thucydides, Plato. Close reading, discussion, and critical writing.
+- **Teaching frame:** The Double Feature — the text, a film, and an album, discussed as one conversation. The ancient question carried into the present decision.
 
-## Outcomes Served
+## Learning Outcomes
 
-- **Judgment**
-- **Articulation**
-- **Breadth of Mind**
+By the end of this course you can:
 
-## What This Course Is About
+1. Read an ancient primary text closely and accurately reconstruct its central argument. → *Breadth of Mind*
+2. Trace one idea across a text, a film, and an album, and defend the connection with evidence from all three. → *Judgment*
+3. Write short critical responses that make a claim, support it from the text, and survive line-editing. → *Articulation*
+4. Produce a made response — essay, short film, recorded piece, or designed object — and defend it in seminar. → *Craft · Articulation*
 
-The oldest stories we have are survival manuals for being human, and they are still about you. Eight weeks inside Homer, the tragedians, and Plato — each unit paired with a film and an album so the conversation crosses three thousand years without slowing down.
+*Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.*
 
 ## The Made Thing
 
-A made response — essay, short film, recorded piece, or designed object — defended in seminar.
+A made response to the ancient world — an essay, a short film, a recorded piece, or a designed object — defended in seminar. It enters your portfolio and is reviewed at the annual gate.
+
+## How You're Assessed
+
+- **Short written responses**, line-edited and revised — the work is the writing, not a quiz about the reading.
+- **The made response**, defended out loud in seminar at the end of the course.
+- **Periodic unassisted writing.** AI tools are open for drafting and study; the institution certifies the human, so part of your writing happens with the tools closed.
+- Everything lands in your **portfolio**, reviewed against the five outcomes at the end-of-year gate.
 
 ## The Daily Path
 
-One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.
+One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course's own day files.
 
-- [Day 01 — The Oldest Story Is About You](day-01.html)
-- Day 02 — *to be written*
-- Day 03 — *to be written*
-- Day 04 — *to be written*
-- Day 05 — *to be written*
-- Day 06 — *to be written*
-- Day 07 — *to be written*
-- Day 08 — *to be written*
-- Day 09 — *to be written*
-- Day 10 — *to be written*
-- Day 11 — *to be written*
-- Day 12 — *to be written*
-- Day 13 — *to be written*
-- Day 14 — *to be written*
-- Day 15 — *to be written*
+<!-- sdit:days:begin -->
+### Day 01 — The Oldest Story Is About You
+
+Ten minutes. One painted cup, eight lines of poetry, one question.
+
+[Begin Day 01 →](day-01.html)
+
+### Day 02 — *coming soon*
+
+Being written — publishes with Week 2. All five courses advance together, week by week.
+
+### Day 03 — *coming soon*
+
+Being written — publishes with Week 3. All five courses advance together, week by week.
+
+### Day 04 — *coming soon*
+
+Being written — publishes with Week 4. All five courses advance together, week by week.
+
+### Day 05 — *coming soon*
+
+Being written — publishes with Week 5. All five courses advance together, week by week.
+
+### Day 06 — *coming soon*
+
+Being written — publishes with Week 6. All five courses advance together, week by week.
+
+### Day 07 — *coming soon*
+
+Being written — publishes with Week 7. All five courses advance together, week by week.
+
+### Day 08 — *coming soon*
+
+Being written — publishes with Week 8. All five courses advance together, week by week.
+
+### Day 09 — *coming soon*
+
+Being written — publishes with Week 9. All five courses advance together, week by week.
+
+### Day 10 — *coming soon*
+
+Being written — publishes with Week 10. All five courses advance together, week by week.
+
+### Day 11 — *coming soon*
+
+Being written — publishes with Week 11. All five courses advance together, week by week.
+
+### Day 12 — *coming soon*
+
+Being written — publishes with Week 12. All five courses advance together, week by week.
+
+### Day 13 — *coming soon*
+
+Being written — publishes with Week 13. All five courses advance together, week by week.
+
+### Day 14 — *coming soon*
+
+Being written — publishes with Week 14. All five courses advance together, week by week.
+
+### Day 15 — *coming soon*
+
+Being written — publishes with Week 15. All five courses advance together, week by week.
+<!-- sdit:days:end -->
 
 ---
 

--- a/courses/MATH-110/index.html
+++ b/courses/MATH-110/index.html
@@ -14,40 +14,71 @@
   <div data-include="/partials/header.html"></div>
   <main>
   <h1 id="math-110-calculus-i">MATH 110 — Calculus I</h1>
-<p><strong>Mathematics &amp; Science</strong> · 4 units · Required core — everyone takes it</p>
+<p><strong>Mathematics &amp; Science</strong> · 4 units · Semester 1 · Required core — everyone takes it</p>
+<h2 id="overview">Overview</h2>
+<p>Calculus is the mathematics of motion, and you already know the motion. Every drop-in, racing line, and fading swell is a curve; the derivative is what it feels like at exactly this instant. At SDIT every concept arrives <strong>physical before formal</strong> — you see it move, then you name it, then you compute with it. The notation is the last step, never the first.</p>
+<p>Taught as <strong>The Mathematics of Motion</strong>: ramp transitions, swell decay, the moment a turn is tightest. By the time limits and derivatives appear as symbols, they&rsquo;re descriptions of things you&rsquo;ve watched happen — which is the only way the symbols ever meant anything to anyone.</p>
+<p>One day a week, about ten minutes a sitting, with problems that start in the world and end on the page. AI tools stay open for exploration; your own unassisted command of the material is examined, because the degree certifies you, not your tools.</p>
 <h2 id="the-two-registers">The Two Registers</h2>
 <ul>
-<li><strong>Catalog register:</strong> Differential calculus — limits, derivatives, optimization, with applications.</li>
-<li><strong>Teaching frame:</strong> Motion: ramp transitions, racing lines, swell decay. Every concept physical before formal.</li>
+<li><strong>Catalog register:</strong> Differential calculus — limits, derivatives, optimization, with applications. Transfer-legible Calculus I.</li>
+<li><strong>Teaching frame:</strong> The Mathematics of Motion — every concept physical before formal: the drop-in, the racing line, the fading swell, finally explained.</li>
 </ul>
-<h2 id="outcomes-served">Outcomes Served</h2>
-<ul>
-<li><strong>Judgment</strong></li>
-<li><strong>Craft</strong></li>
-</ul>
-<h2 id="what-this-course-is-about">What This Course Is About</h2>
-<p>Calculus is the mathematics of change, and you already have the intuition — every drop-in, every braking point, every fading swell is a derivative you can feel. This course attaches the notation to what your body already knows.</p>
+<h2 id="learning-outcomes">Learning Outcomes</h2>
+<p>By the end of this course you can:</p>
+<ol>
+<li>Evaluate limits and compute derivatives of polynomial, trigonometric, exponential, and composed functions. → <em>Craft</em></li>
+<li>Model position, velocity, and acceleration from real motion, and interpret a derivative physically before symbolically. → <em>Judgment</em></li>
+<li>Solve optimization and related-rates problems drawn from physical situations, and defend the setup, not just the answer. → <em>Judgment · Craft</em></li>
+<li>Move fluently between graphical, numerical, and symbolic representations of the same behavior. → <em>Breadth of Mind</em></li>
+<li>Demonstrate the above unassisted, in periodic written examinations. → <em>Command of Intelligence</em></li>
+</ol>
+<p><em>Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.</em></p>
 <h2 id="the-made-thing">The Made Thing</h2>
-<p>A motion study — a real moving thing measured, modeled, and explained with the calculus that governs it.</p>
-<h2 id="the-daily-path">The Daily Path</h2>
-<p>One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.</p>
+<p>A motion study: a real moving thing — a ride, a wave, a thrown object, a song&rsquo;s envelope — measured, modeled, and explained in the language of derivatives, presented with the data and the mathematics side by side.</p>
+<h2 id="how-youre-assessed">How You&rsquo;re Assessed</h2>
 <ul>
-<li><a href="day-01.html">Day 01 — Zoom In Until It&rsquo;s Straight</a></li>
-<li>Day 02 — <em>to be written</em></li>
-<li>Day 03 — <em>to be written</em></li>
-<li>Day 04 — <em>to be written</em></li>
-<li>Day 05 — <em>to be written</em></li>
-<li>Day 06 — <em>to be written</em></li>
-<li>Day 07 — <em>to be written</em></li>
-<li>Day 08 — <em>to be written</em></li>
-<li>Day 09 — <em>to be written</em></li>
-<li>Day 10 — <em>to be written</em></li>
-<li>Day 11 — <em>to be written</em></li>
-<li>Day 12 — <em>to be written</em></li>
-<li>Day 13 — <em>to be written</em></li>
-<li>Day 14 — <em>to be written</em></li>
-<li>Day 15 — <em>to be written</em></li>
+<li><strong>Weekly problem sets</strong> — AI tools open; what&rsquo;s graded is your setup, your verification, and your explanation.</li>
+<li><strong>The motion study</strong>, presented and defended.</li>
+<li><strong>Unassisted written examinations</strong> — limits, derivatives, and modeling with the tools closed. AI-native, not AI-dependent.</li>
+<li>Everything lands in your <strong>portfolio</strong>, reviewed against the five outcomes at the end-of-year gate.</li>
 </ul>
+<h2 id="the-daily-path">The Daily Path</h2>
+<p>One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course&rsquo;s own day files.</p>
+<!-- sdit:days:begin -->
+<h3 id="day-01-zoom-in-until-its-straight">Day 01 — Zoom In Until It&rsquo;s Straight</h3>
+<p>Ten minutes. One video, one trick, one question. No equations today.</p>
+<p><a href="day-01.html">Begin Day 01 →</a></p>
+<h3 id="day-02-coming-soon">Day 02 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 2. All five courses advance together, week by week.</p>
+<h3 id="day-03-coming-soon">Day 03 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 3. All five courses advance together, week by week.</p>
+<h3 id="day-04-coming-soon">Day 04 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 4. All five courses advance together, week by week.</p>
+<h3 id="day-05-coming-soon">Day 05 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 5. All five courses advance together, week by week.</p>
+<h3 id="day-06-coming-soon">Day 06 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 6. All five courses advance together, week by week.</p>
+<h3 id="day-07-coming-soon">Day 07 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 7. All five courses advance together, week by week.</p>
+<h3 id="day-08-coming-soon">Day 08 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 8. All five courses advance together, week by week.</p>
+<h3 id="day-09-coming-soon">Day 09 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 9. All five courses advance together, week by week.</p>
+<h3 id="day-10-coming-soon">Day 10 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 10. All five courses advance together, week by week.</p>
+<h3 id="day-11-coming-soon">Day 11 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 11. All five courses advance together, week by week.</p>
+<h3 id="day-12-coming-soon">Day 12 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 12. All five courses advance together, week by week.</p>
+<h3 id="day-13-coming-soon">Day 13 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 13. All five courses advance together, week by week.</p>
+<h3 id="day-14-coming-soon">Day 14 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 14. All five courses advance together, week by week.</p>
+<h3 id="day-15-coming-soon">Day 15 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 15. All five courses advance together, week by week.</p>
+<!-- sdit:days:end -->
+
 <hr />
 <p><em>Every course here is built to one standard: it ends in a made thing you can show, and it ships day by day.</em></p>
   </main>

--- a/courses/MATH-110/index.md
+++ b/courses/MATH-110/index.md
@@ -4,50 +4,117 @@ title: "MATH 110 — Calculus I"
 course_code: MATH 110
 units: 4
 thread: Mathematics & Science
+semester: 1
 status: day1
 ---
 
 # MATH 110 — Calculus I
 
-**Mathematics & Science** · 4 units · Required core — everyone takes it
+**Mathematics & Science** · 4 units · Semester 1 · Required core — everyone takes it
+
+## Overview
+
+Calculus is the mathematics of motion, and you already know the motion. Every drop-in, racing line, and fading swell is a curve; the derivative is what it feels like at exactly this instant. At SDIT every concept arrives **physical before formal** — you see it move, then you name it, then you compute with it. The notation is the last step, never the first.
+
+Taught as **The Mathematics of Motion**: ramp transitions, swell decay, the moment a turn is tightest. By the time limits and derivatives appear as symbols, they're descriptions of things you've watched happen — which is the only way the symbols ever meant anything to anyone.
+
+One day a week, about ten minutes a sitting, with problems that start in the world and end on the page. AI tools stay open for exploration; your own unassisted command of the material is examined, because the degree certifies you, not your tools.
 
 ## The Two Registers
 
-- **Catalog register:** Differential calculus — limits, derivatives, optimization, with applications.
-- **Teaching frame:** Motion: ramp transitions, racing lines, swell decay. Every concept physical before formal.
+- **Catalog register:** Differential calculus — limits, derivatives, optimization, with applications. Transfer-legible Calculus I.
+- **Teaching frame:** The Mathematics of Motion — every concept physical before formal: the drop-in, the racing line, the fading swell, finally explained.
 
-## Outcomes Served
+## Learning Outcomes
 
-- **Judgment**
-- **Craft**
+By the end of this course you can:
 
-## What This Course Is About
+1. Evaluate limits and compute derivatives of polynomial, trigonometric, exponential, and composed functions. → *Craft*
+2. Model position, velocity, and acceleration from real motion, and interpret a derivative physically before symbolically. → *Judgment*
+3. Solve optimization and related-rates problems drawn from physical situations, and defend the setup, not just the answer. → *Judgment · Craft*
+4. Move fluently between graphical, numerical, and symbolic representations of the same behavior. → *Breadth of Mind*
+5. Demonstrate the above unassisted, in periodic written examinations. → *Command of Intelligence*
 
-Calculus is the mathematics of change, and you already have the intuition — every drop-in, every braking point, every fading swell is a derivative you can feel. This course attaches the notation to what your body already knows.
+*Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.*
 
 ## The Made Thing
 
-A motion study — a real moving thing measured, modeled, and explained with the calculus that governs it.
+A motion study: a real moving thing — a ride, a wave, a thrown object, a song's envelope — measured, modeled, and explained in the language of derivatives, presented with the data and the mathematics side by side.
+
+## How You're Assessed
+
+- **Weekly problem sets** — AI tools open; what's graded is your setup, your verification, and your explanation.
+- **The motion study**, presented and defended.
+- **Unassisted written examinations** — limits, derivatives, and modeling with the tools closed. AI-native, not AI-dependent.
+- Everything lands in your **portfolio**, reviewed against the five outcomes at the end-of-year gate.
 
 ## The Daily Path
 
-One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.
+One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course's own day files.
 
-- [Day 01 — Zoom In Until It's Straight](day-01.html)
-- Day 02 — *to be written*
-- Day 03 — *to be written*
-- Day 04 — *to be written*
-- Day 05 — *to be written*
-- Day 06 — *to be written*
-- Day 07 — *to be written*
-- Day 08 — *to be written*
-- Day 09 — *to be written*
-- Day 10 — *to be written*
-- Day 11 — *to be written*
-- Day 12 — *to be written*
-- Day 13 — *to be written*
-- Day 14 — *to be written*
-- Day 15 — *to be written*
+<!-- sdit:days:begin -->
+### Day 01 — Zoom In Until It's Straight
+
+Ten minutes. One video, one trick, one question. No equations today.
+
+[Begin Day 01 →](day-01.html)
+
+### Day 02 — *coming soon*
+
+Being written — publishes with Week 2. All five courses advance together, week by week.
+
+### Day 03 — *coming soon*
+
+Being written — publishes with Week 3. All five courses advance together, week by week.
+
+### Day 04 — *coming soon*
+
+Being written — publishes with Week 4. All five courses advance together, week by week.
+
+### Day 05 — *coming soon*
+
+Being written — publishes with Week 5. All five courses advance together, week by week.
+
+### Day 06 — *coming soon*
+
+Being written — publishes with Week 6. All five courses advance together, week by week.
+
+### Day 07 — *coming soon*
+
+Being written — publishes with Week 7. All five courses advance together, week by week.
+
+### Day 08 — *coming soon*
+
+Being written — publishes with Week 8. All five courses advance together, week by week.
+
+### Day 09 — *coming soon*
+
+Being written — publishes with Week 9. All five courses advance together, week by week.
+
+### Day 10 — *coming soon*
+
+Being written — publishes with Week 10. All five courses advance together, week by week.
+
+### Day 11 — *coming soon*
+
+Being written — publishes with Week 11. All five courses advance together, week by week.
+
+### Day 12 — *coming soon*
+
+Being written — publishes with Week 12. All five courses advance together, week by week.
+
+### Day 13 — *coming soon*
+
+Being written — publishes with Week 13. All five courses advance together, week by week.
+
+### Day 14 — *coming soon*
+
+Being written — publishes with Week 14. All five courses advance together, week by week.
+
+### Day 15 — *coming soon*
+
+Being written — publishes with Week 15. All five courses advance together, week by week.
+<!-- sdit:days:end -->
 
 ---
 

--- a/courses/PHYS-110/index.html
+++ b/courses/PHYS-110/index.html
@@ -14,40 +14,71 @@
   <div data-include="/partials/header.html"></div>
   <main>
   <h1 id="phys-110-mechanics">PHYS 110 — Mechanics</h1>
-<p><strong>Mathematics &amp; Science</strong> · 4 units · Required core — everyone takes it</p>
+<p><strong>Mathematics &amp; Science</strong> · 4 units · Semester 1 · Required core — everyone takes it</p>
+<h2 id="overview">Overview</h2>
+<p>Mechanics is the study of how things move, and San Diego is the laboratory. Forces on a rail, pumping a transition, the bottom turn, lean angle through a corner — every law in this course is something your body already negotiates. At SDIT the lab is <strong>on the sand and in the water</strong>: you measure the world you actually live in, then meet the equations that were describing it all along.</p>
+<p>Taught as <strong>How Things Move</strong>: the ocean and the board first, Newton second. A wave is a lecture on energy transport; a skateboard is an instrument for studying rotational inertia. No concept arrives as notation first — force is a bottom turn before it is a vector.</p>
+<p>One day a week, about ten minutes a sitting, building toward real measurement, honest uncertainty, and a lab artifact you can defend.</p>
 <h2 id="the-two-registers">The Two Registers</h2>
 <ul>
-<li><strong>Catalog register:</strong> Classical mechanics — kinematics, forces, energy, momentum, rotation; laboratory.</li>
-<li><strong>Teaching frame:</strong> The ocean and the board — forces on a rail, pumping a transition, bottom turns, lean angle. Lab on the sand and in the water.</li>
+<li><strong>Catalog register:</strong> Classical mechanics — kinematics, forces, energy, momentum, rotation; laboratory. Transfer-legible introductory mechanics.</li>
+<li><strong>Teaching frame:</strong> How Things Move — the ocean and the board; lab on the sand and in the water.</li>
 </ul>
-<h2 id="outcomes-served">Outcomes Served</h2>
-<ul>
-<li><strong>Judgment</strong></li>
-<li><strong>Craft</strong></li>
-</ul>
-<h2 id="what-this-course-is-about">What This Course Is About</h2>
-<p>Forces, energy, and momentum, learned where they actually live — on the wave, the ramp, and the road. The lab is the beach; the problem sets are things you can feel in your knees.</p>
+<h2 id="learning-outcomes">Learning Outcomes</h2>
+<p>By the end of this course you can:</p>
+<ol>
+<li>Apply Newton&rsquo;s laws to analyze real one- and two-dimensional motion, including friction and circular motion. → <em>Craft</em></li>
+<li>Use conservation of energy and momentum to predict outcomes you can then check by measurement. → <em>Judgment</em></li>
+<li>Design a simple measurement, estimate its uncertainty, and say honestly what the data can and cannot support. → <em>Judgment · Command of Intelligence</em></li>
+<li>Keep a lab notebook that another student could reproduce your work from. → <em>Articulation</em></li>
+<li>Demonstrate the above unassisted, in periodic written examinations. → <em>Command of Intelligence</em></li>
+</ol>
+<p><em>Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.</em></p>
 <h2 id="the-made-thing">The Made Thing</h2>
-<p>A force analysis of a real maneuver — measured, diagrammed, defended.</p>
-<h2 id="the-daily-path">The Daily Path</h2>
-<p>One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.</p>
+<p>A defended lab artifact: a measurement of something real — a wave, a ramp, a wheel, a fall — with the apparatus, the data, the uncertainty, and the physics presented as one piece of work.</p>
+<h2 id="how-youre-assessed">How You&rsquo;re Assessed</h2>
 <ul>
-<li><a href="day-01.html">Day 01 — The Wave Is a Lecture</a></li>
-<li>Day 02 — <em>to be written</em></li>
-<li>Day 03 — <em>to be written</em></li>
-<li>Day 04 — <em>to be written</em></li>
-<li>Day 05 — <em>to be written</em></li>
-<li>Day 06 — <em>to be written</em></li>
-<li>Day 07 — <em>to be written</em></li>
-<li>Day 08 — <em>to be written</em></li>
-<li>Day 09 — <em>to be written</em></li>
-<li>Day 10 — <em>to be written</em></li>
-<li>Day 11 — <em>to be written</em></li>
-<li>Day 12 — <em>to be written</em></li>
-<li>Day 13 — <em>to be written</em></li>
-<li>Day 14 — <em>to be written</em></li>
-<li>Day 15 — <em>to be written</em></li>
+<li><strong>Lab work and notebooks</strong> — measurement, uncertainty, and reproducibility are graded, not just answers.</li>
+<li><strong>The lab artifact</strong>, presented and defended.</li>
+<li><strong>Unassisted written examinations</strong> — the laws, applied with the tools closed.</li>
+<li>Everything lands in your <strong>portfolio</strong>, reviewed against the five outcomes at the end-of-year gate.</li>
 </ul>
+<h2 id="the-daily-path">The Daily Path</h2>
+<p>One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course&rsquo;s own day files.</p>
+<!-- sdit:days:begin -->
+<h3 id="day-01-the-wave-is-a-lecture">Day 01 — The Wave Is a Lecture</h3>
+<p>Ten minutes. One woodblock print, one physicist with a flower, one question.</p>
+<p><a href="day-01.html">Begin Day 01 →</a></p>
+<h3 id="day-02-coming-soon">Day 02 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 2. All five courses advance together, week by week.</p>
+<h3 id="day-03-coming-soon">Day 03 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 3. All five courses advance together, week by week.</p>
+<h3 id="day-04-coming-soon">Day 04 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 4. All five courses advance together, week by week.</p>
+<h3 id="day-05-coming-soon">Day 05 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 5. All five courses advance together, week by week.</p>
+<h3 id="day-06-coming-soon">Day 06 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 6. All five courses advance together, week by week.</p>
+<h3 id="day-07-coming-soon">Day 07 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 7. All five courses advance together, week by week.</p>
+<h3 id="day-08-coming-soon">Day 08 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 8. All five courses advance together, week by week.</p>
+<h3 id="day-09-coming-soon">Day 09 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 9. All five courses advance together, week by week.</p>
+<h3 id="day-10-coming-soon">Day 10 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 10. All five courses advance together, week by week.</p>
+<h3 id="day-11-coming-soon">Day 11 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 11. All five courses advance together, week by week.</p>
+<h3 id="day-12-coming-soon">Day 12 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 12. All five courses advance together, week by week.</p>
+<h3 id="day-13-coming-soon">Day 13 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 13. All five courses advance together, week by week.</p>
+<h3 id="day-14-coming-soon">Day 14 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 14. All five courses advance together, week by week.</p>
+<h3 id="day-15-coming-soon">Day 15 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 15. All five courses advance together, week by week.</p>
+<!-- sdit:days:end -->
+
 <hr />
 <p><em>Every course here is built to one standard: it ends in a made thing you can show, and it ships day by day.</em></p>
   </main>

--- a/courses/PHYS-110/index.md
+++ b/courses/PHYS-110/index.md
@@ -4,50 +4,117 @@ title: "PHYS 110 — Mechanics"
 course_code: PHYS 110
 units: 4
 thread: Mathematics & Science
+semester: 1
 status: day1
 ---
 
 # PHYS 110 — Mechanics
 
-**Mathematics & Science** · 4 units · Required core — everyone takes it
+**Mathematics & Science** · 4 units · Semester 1 · Required core — everyone takes it
+
+## Overview
+
+Mechanics is the study of how things move, and San Diego is the laboratory. Forces on a rail, pumping a transition, the bottom turn, lean angle through a corner — every law in this course is something your body already negotiates. At SDIT the lab is **on the sand and in the water**: you measure the world you actually live in, then meet the equations that were describing it all along.
+
+Taught as **How Things Move**: the ocean and the board first, Newton second. A wave is a lecture on energy transport; a skateboard is an instrument for studying rotational inertia. No concept arrives as notation first — force is a bottom turn before it is a vector.
+
+One day a week, about ten minutes a sitting, building toward real measurement, honest uncertainty, and a lab artifact you can defend.
 
 ## The Two Registers
 
-- **Catalog register:** Classical mechanics — kinematics, forces, energy, momentum, rotation; laboratory.
-- **Teaching frame:** The ocean and the board — forces on a rail, pumping a transition, bottom turns, lean angle. Lab on the sand and in the water.
+- **Catalog register:** Classical mechanics — kinematics, forces, energy, momentum, rotation; laboratory. Transfer-legible introductory mechanics.
+- **Teaching frame:** How Things Move — the ocean and the board; lab on the sand and in the water.
 
-## Outcomes Served
+## Learning Outcomes
 
-- **Judgment**
-- **Craft**
+By the end of this course you can:
 
-## What This Course Is About
+1. Apply Newton's laws to analyze real one- and two-dimensional motion, including friction and circular motion. → *Craft*
+2. Use conservation of energy and momentum to predict outcomes you can then check by measurement. → *Judgment*
+3. Design a simple measurement, estimate its uncertainty, and say honestly what the data can and cannot support. → *Judgment · Command of Intelligence*
+4. Keep a lab notebook that another student could reproduce your work from. → *Articulation*
+5. Demonstrate the above unassisted, in periodic written examinations. → *Command of Intelligence*
 
-Forces, energy, and momentum, learned where they actually live — on the wave, the ramp, and the road. The lab is the beach; the problem sets are things you can feel in your knees.
+*Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.*
 
 ## The Made Thing
 
-A force analysis of a real maneuver — measured, diagrammed, defended.
+A defended lab artifact: a measurement of something real — a wave, a ramp, a wheel, a fall — with the apparatus, the data, the uncertainty, and the physics presented as one piece of work.
+
+## How You're Assessed
+
+- **Lab work and notebooks** — measurement, uncertainty, and reproducibility are graded, not just answers.
+- **The lab artifact**, presented and defended.
+- **Unassisted written examinations** — the laws, applied with the tools closed.
+- Everything lands in your **portfolio**, reviewed against the five outcomes at the end-of-year gate.
 
 ## The Daily Path
 
-One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.
+One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course's own day files.
 
-- [Day 01 — The Wave Is a Lecture](day-01.html)
-- Day 02 — *to be written*
-- Day 03 — *to be written*
-- Day 04 — *to be written*
-- Day 05 — *to be written*
-- Day 06 — *to be written*
-- Day 07 — *to be written*
-- Day 08 — *to be written*
-- Day 09 — *to be written*
-- Day 10 — *to be written*
-- Day 11 — *to be written*
-- Day 12 — *to be written*
-- Day 13 — *to be written*
-- Day 14 — *to be written*
-- Day 15 — *to be written*
+<!-- sdit:days:begin -->
+### Day 01 — The Wave Is a Lecture
+
+Ten minutes. One woodblock print, one physicist with a flower, one question.
+
+[Begin Day 01 →](day-01.html)
+
+### Day 02 — *coming soon*
+
+Being written — publishes with Week 2. All five courses advance together, week by week.
+
+### Day 03 — *coming soon*
+
+Being written — publishes with Week 3. All five courses advance together, week by week.
+
+### Day 04 — *coming soon*
+
+Being written — publishes with Week 4. All five courses advance together, week by week.
+
+### Day 05 — *coming soon*
+
+Being written — publishes with Week 5. All five courses advance together, week by week.
+
+### Day 06 — *coming soon*
+
+Being written — publishes with Week 6. All five courses advance together, week by week.
+
+### Day 07 — *coming soon*
+
+Being written — publishes with Week 7. All five courses advance together, week by week.
+
+### Day 08 — *coming soon*
+
+Being written — publishes with Week 8. All five courses advance together, week by week.
+
+### Day 09 — *coming soon*
+
+Being written — publishes with Week 9. All five courses advance together, week by week.
+
+### Day 10 — *coming soon*
+
+Being written — publishes with Week 10. All five courses advance together, week by week.
+
+### Day 11 — *coming soon*
+
+Being written — publishes with Week 11. All five courses advance together, week by week.
+
+### Day 12 — *coming soon*
+
+Being written — publishes with Week 12. All five courses advance together, week by week.
+
+### Day 13 — *coming soon*
+
+Being written — publishes with Week 13. All five courses advance together, week by week.
+
+### Day 14 — *coming soon*
+
+Being written — publishes with Week 14. All five courses advance together, week by week.
+
+### Day 15 — *coming soon*
+
+Being written — publishes with Week 15. All five courses advance together, week by week.
+<!-- sdit:days:end -->
 
 ---
 

--- a/courses/WKSP-101/index.html
+++ b/courses/WKSP-101/index.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WKSP 101–402 — The Workshop (Bottega) — SDIT</title>
+  <title>WKSP 101 — The Workshop — SDIT</title>
   <link rel="stylesheet" href="../../assets/site.css" />
   <script src="../../assets/js/site-paths.js" defer></script>
   <script src="../../assets/js/includes.js" defer></script>
@@ -13,41 +13,71 @@
 <body>
   <div data-include="/partials/header.html"></div>
   <main>
-  <h1 id="wksp-101402-the-workshop-bottega">WKSP 101–402 — The Workshop (Bottega)</h1>
-<p><strong>The Workshop</strong> · 2 per semester units · Required core — everyone takes it</p>
+  <h1 id="wksp-101-the-workshop">WKSP 101 — The Workshop</h1>
+<p><strong>The Workshop</strong> · 2 units · Semester 1 · Required core — every semester, everyone</p>
+<h2 id="overview">Overview</h2>
+<p>The Workshop is the bottega — the room where everything else in the curriculum becomes real. Every semester, every student, on a project team that ships. Semester 1 is your first build: small, finished, and yours, because da Vinci didn&rsquo;t start with the Last Supper and you don&rsquo;t start with a capstone.</p>
+<p>Materials rotate through the region&rsquo;s craft traditions — surfboard and skateboard construction, amplifier and pedal electronics, camera rigs, drones and ocean sensors — but the first semester&rsquo;s law is simpler: <strong>make anything, and finish it</strong>. Finishing is the skill. Critique is the method. The year ends with your work in a public exhibition, which is not a metaphor: people you don&rsquo;t know will look at the thing you made.</p>
+<p>One day a week on the page, about ten minutes a sitting — and then your hands take over.</p>
 <h2 id="the-two-registers">The Two Registers</h2>
 <ul>
-<li><strong>Catalog register:</strong> Project-based fabrication and design practicum, taken every semester (WKSP 101 through 402).</li>
-<li><strong>Teaching frame:</strong> A project team that ships — boards, amplifier and pedal electronics, motorcycle mechanics, camera rigs, drones and ocean sensors. External clients from Year 2; public exhibition every year.</li>
+<li><strong>Catalog register:</strong> Project-based fabrication and design practicum — tool skills, materials, iterative making, documentation, exhibition. First course of the eight-semester Workshop sequence (WKSP 101–402).</li>
+<li><strong>Teaching frame:</strong> The bottega — a project team that ships. Make anything; finish it; show it in public.</li>
 </ul>
-<h2 id="outcomes-served">Outcomes Served</h2>
-<ul>
-<li><strong>Craft</strong></li>
-<li><strong>Judgment</strong></li>
-</ul>
-<h2 id="what-this-course-is-about">What This Course Is About</h2>
-<p>The bottega — the room where mastery is transmitted through making. Every semester, every student, on a project team that ships something real. The materials rotate through the region&rsquo;s craft traditions; the standard never does.</p>
+<h2 id="learning-outcomes">Learning Outcomes</h2>
+<p>By the end of this course you can:</p>
+<ol>
+<li>Scope a project you can actually finish in a semester, and finish it. → <em>Judgment · Craft</em></li>
+<li>Use basic fabrication tools and materials safely and competently. → <em>Craft</em></li>
+<li>Take critique, iterate, and show the difference between draft and final. → <em>Judgment</em></li>
+<li>Document a build so someone else could follow it — photos, notes, decisions. → <em>Articulation</em></li>
+<li>Exhibit finished work in public and talk about it. → <em>Articulation</em></li>
+</ol>
+<p><em>Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.</em></p>
 <h2 id="the-made-thing">The Made Thing</h2>
-<p>The shipped project, exhibited publicly, every single semester.</p>
-<h2 id="the-daily-path">The Daily Path</h2>
-<p>One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.</p>
+<p>The build itself — finished, documented, and shown at the year-end public exhibition alongside every other first-year&rsquo;s work.</p>
+<h2 id="how-youre-assessed">How You&rsquo;re Assessed</h2>
 <ul>
-<li><a href="day-01.html">Day 01 — Make Anything</a></li>
-<li>Day 02 — <em>to be written</em></li>
-<li>Day 03 — <em>to be written</em></li>
-<li>Day 04 — <em>to be written</em></li>
-<li>Day 05 — <em>to be written</em></li>
-<li>Day 06 — <em>to be written</em></li>
-<li>Day 07 — <em>to be written</em></li>
-<li>Day 08 — <em>to be written</em></li>
-<li>Day 09 — <em>to be written</em></li>
-<li>Day 10 — <em>to be written</em></li>
-<li>Day 11 — <em>to be written</em></li>
-<li>Day 12 — <em>to be written</em></li>
-<li>Day 13 — <em>to be written</em></li>
-<li>Day 14 — <em>to be written</em></li>
-<li>Day 15 — <em>to be written</em></li>
+<li><strong>The build</strong> — scoped, finished, and functional. Finishing is graded.</li>
+<li><strong>The documentation</strong> — a build log someone else could learn from.</li>
+<li><strong>Portfolio review and public exhibition</strong> — the Workshop is assessed the way working studios are: by the work, shown.</li>
 </ul>
+<h2 id="the-daily-path">The Daily Path</h2>
+<p>One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course&rsquo;s own day files.</p>
+<!-- sdit:days:begin -->
+<h3 id="day-01-make-anything">Day 01 — Make Anything</h3>
+<p>Ten minutes — and for once, only two of them are reading. This is the Workshop. It starts with your hands.</p>
+<p><a href="day-01.html">Begin Day 01 →</a></p>
+<h3 id="day-02-coming-soon">Day 02 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 2. All five courses advance together, week by week.</p>
+<h3 id="day-03-coming-soon">Day 03 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 3. All five courses advance together, week by week.</p>
+<h3 id="day-04-coming-soon">Day 04 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 4. All five courses advance together, week by week.</p>
+<h3 id="day-05-coming-soon">Day 05 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 5. All five courses advance together, week by week.</p>
+<h3 id="day-06-coming-soon">Day 06 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 6. All five courses advance together, week by week.</p>
+<h3 id="day-07-coming-soon">Day 07 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 7. All five courses advance together, week by week.</p>
+<h3 id="day-08-coming-soon">Day 08 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 8. All five courses advance together, week by week.</p>
+<h3 id="day-09-coming-soon">Day 09 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 9. All five courses advance together, week by week.</p>
+<h3 id="day-10-coming-soon">Day 10 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 10. All five courses advance together, week by week.</p>
+<h3 id="day-11-coming-soon">Day 11 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 11. All five courses advance together, week by week.</p>
+<h3 id="day-12-coming-soon">Day 12 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 12. All five courses advance together, week by week.</p>
+<h3 id="day-13-coming-soon">Day 13 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 13. All five courses advance together, week by week.</p>
+<h3 id="day-14-coming-soon">Day 14 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 14. All five courses advance together, week by week.</p>
+<h3 id="day-15-coming-soon">Day 15 — <em>coming soon</em></h3>
+<p>Being written — publishes with Week 15. All five courses advance together, week by week.</p>
+<!-- sdit:days:end -->
+
 <hr />
 <p><em>Every course here is built to one standard: it ends in a made thing you can show, and it ships day by day.</em></p>
   </main>

--- a/courses/WKSP-101/index.md
+++ b/courses/WKSP-101/index.md
@@ -1,53 +1,119 @@
 ---
 id: wksp-101
-title: "WKSP 101–402 — The Workshop (Bottega)"
-course_code: WKSP 101–402
-units: 2 per semester
+title: "WKSP 101 — The Workshop"
+course_code: WKSP 101
+units: 2
 thread: The Workshop
+semester: 1
 status: day1
 ---
 
-# WKSP 101–402 — The Workshop (Bottega)
+# WKSP 101 — The Workshop
 
-**The Workshop** · 2 per semester units · Required core — everyone takes it
+**The Workshop** · 2 units · Semester 1 · Required core — every semester, everyone
+
+## Overview
+
+The Workshop is the bottega — the room where everything else in the curriculum becomes real. Every semester, every student, on a project team that ships. Semester 1 is your first build: small, finished, and yours, because da Vinci didn't start with the Last Supper and you don't start with a capstone.
+
+Materials rotate through the region's craft traditions — surfboard and skateboard construction, amplifier and pedal electronics, camera rigs, drones and ocean sensors — but the first semester's law is simpler: **make anything, and finish it**. Finishing is the skill. Critique is the method. The year ends with your work in a public exhibition, which is not a metaphor: people you don't know will look at the thing you made.
+
+One day a week on the page, about ten minutes a sitting — and then your hands take over.
 
 ## The Two Registers
 
-- **Catalog register:** Project-based fabrication and design practicum, taken every semester (WKSP 101 through 402).
-- **Teaching frame:** A project team that ships — boards, amplifier and pedal electronics, motorcycle mechanics, camera rigs, drones and ocean sensors. External clients from Year 2; public exhibition every year.
+- **Catalog register:** Project-based fabrication and design practicum — tool skills, materials, iterative making, documentation, exhibition. First course of the eight-semester Workshop sequence (WKSP 101–402).
+- **Teaching frame:** The bottega — a project team that ships. Make anything; finish it; show it in public.
 
-## Outcomes Served
+## Learning Outcomes
 
-- **Craft**
-- **Judgment**
+By the end of this course you can:
 
-## What This Course Is About
+1. Scope a project you can actually finish in a semester, and finish it. → *Judgment · Craft*
+2. Use basic fabrication tools and materials safely and competently. → *Craft*
+3. Take critique, iterate, and show the difference between draft and final. → *Judgment*
+4. Document a build so someone else could follow it — photos, notes, decisions. → *Articulation*
+5. Exhibit finished work in public and talk about it. → *Articulation*
 
-The bottega — the room where mastery is transmitted through making. Every semester, every student, on a project team that ships something real. The materials rotate through the region's craft traditions; the standard never does.
+*Each outcome maps to the five institutional outcomes (Judgment, Command of Intelligence, Craft, Articulation, Breadth of Mind) — the assessment spine of the degree and its accreditation evidence file.*
 
 ## The Made Thing
 
-The shipped project, exhibited publicly, every single semester.
+The build itself — finished, documented, and shown at the year-end public exhibition alongside every other first-year's work.
+
+## How You're Assessed
+
+- **The build** — scoped, finished, and functional. Finishing is graded.
+- **The documentation** — a build log someone else could learn from.
+- **Portfolio review and public exhibition** — the Workshop is assessed the way working studios are: by the work, shown.
 
 ## The Daily Path
 
-One session per course day — each one designed to look easy and pull you in. Day 1 is live below; the rest of the daily path is being written.
+One session per course day — each one built to look easy and pull you in: one thing to experience, one idea, one question to carry. The schedule below is generated from the course's own day files.
 
-- [Day 01 — Make Anything](day-01.html)
-- Day 02 — *to be written*
-- Day 03 — *to be written*
-- Day 04 — *to be written*
-- Day 05 — *to be written*
-- Day 06 — *to be written*
-- Day 07 — *to be written*
-- Day 08 — *to be written*
-- Day 09 — *to be written*
-- Day 10 — *to be written*
-- Day 11 — *to be written*
-- Day 12 — *to be written*
-- Day 13 — *to be written*
-- Day 14 — *to be written*
-- Day 15 — *to be written*
+<!-- sdit:days:begin -->
+### Day 01 — Make Anything
+
+Ten minutes — and for once, only two of them are reading. This is the Workshop. It starts with your hands.
+
+[Begin Day 01 →](day-01.html)
+
+### Day 02 — *coming soon*
+
+Being written — publishes with Week 2. All five courses advance together, week by week.
+
+### Day 03 — *coming soon*
+
+Being written — publishes with Week 3. All five courses advance together, week by week.
+
+### Day 04 — *coming soon*
+
+Being written — publishes with Week 4. All five courses advance together, week by week.
+
+### Day 05 — *coming soon*
+
+Being written — publishes with Week 5. All five courses advance together, week by week.
+
+### Day 06 — *coming soon*
+
+Being written — publishes with Week 6. All five courses advance together, week by week.
+
+### Day 07 — *coming soon*
+
+Being written — publishes with Week 7. All five courses advance together, week by week.
+
+### Day 08 — *coming soon*
+
+Being written — publishes with Week 8. All five courses advance together, week by week.
+
+### Day 09 — *coming soon*
+
+Being written — publishes with Week 9. All five courses advance together, week by week.
+
+### Day 10 — *coming soon*
+
+Being written — publishes with Week 10. All five courses advance together, week by week.
+
+### Day 11 — *coming soon*
+
+Being written — publishes with Week 11. All five courses advance together, week by week.
+
+### Day 12 — *coming soon*
+
+Being written — publishes with Week 12. All five courses advance together, week by week.
+
+### Day 13 — *coming soon*
+
+Being written — publishes with Week 13. All five courses advance together, week by week.
+
+### Day 14 — *coming soon*
+
+Being written — publishes with Week 14. All five courses advance together, week by week.
+
+### Day 15 — *coming soon*
+
+Being written — publishes with Week 15. All five courses advance together, week by week.
+<!-- sdit:days:end -->
 
 ---
 

--- a/curriculum/schedule.html
+++ b/curriculum/schedule.html
@@ -53,22 +53,24 @@
       </div>
     </section>
 
-    <!-- ============ WEEK 1 ============ -->
+    <!-- ============ THE WEEKS (generated from course day files) ============ -->
+    <!-- sdit:weeks:begin -->
     <section class="article" id="week-1">
       <div class="frame article-grid">
         <div class="article-label">Week 1<span class="num">Start Here</span></div>
         <div class="article-body">
-          <nav class="ledger" aria-label="Week one" style="margin-top:0.5rem;">
-            <a href="/courses/HUM-101/day-01.html"><span class="l-name">Mon · The Ancient World</span><span class="l-meta">the oldest story →</span></a>
-            <a href="/courses/MATH-110/day-01.html"><span class="l-name">Tue · The Mathematics of Motion</span><span class="l-meta">zoom in until it's straight →</span></a>
-            <a href="/courses/PHYS-110/day-01.html"><span class="l-name">Wed · How Things Move</span><span class="l-meta">the wave is a lecture →</span></a>
-            <a href="/courses/CS-110/day-01.html"><span class="l-name">Thu · Speaking to Machines</span><span class="l-meta">the literal apprentice →</span></a>
-            <a href="/courses/WKSP-101/day-01.html"><span class="l-name">Fri · The Workshop</span><span class="l-meta">make anything →</span></a>
+          <nav class="ledger" aria-label="Week 1" style="margin-top:0.5rem;">
+            <a href="/courses/HUM-101/day-01.html"><span class="l-name">Mon · The Ancient World</span><span class="l-meta">The Oldest Story Is About You →</span></a>
+            <a href="/courses/MATH-110/day-01.html"><span class="l-name">Tue · The Mathematics of Motion</span><span class="l-meta">Zoom In Until It's Straight →</span></a>
+            <a href="/courses/PHYS-110/day-01.html"><span class="l-name">Wed · How Things Move</span><span class="l-meta">The Wave Is a Lecture →</span></a>
+            <a href="/courses/CS-110/day-01.html"><span class="l-name">Thu · Speaking to Machines</span><span class="l-meta">The Very Fast, Very Literal Apprentice →</span></a>
+            <a href="/courses/WKSP-101/day-01.html"><span class="l-name">Fri · The Workshop</span><span class="l-meta">Make Anything →</span></a>
           </nav>
           <p style="margin-top:1rem;font-size:0.88rem;color:var(--muted);">One schedule serves everyone for the first two years — the Foundation is identical for every student.</p>
         </div>
       </div>
     </section>
+    <!-- sdit:weeks:end -->
 
     <!-- ============ A DAY IS ============ -->
     <section class="article" id="a-day">

--- a/institute/sdit-bible.html
+++ b/institute/sdit-bible.html
@@ -6,9 +6,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Plan — SDIT Institutional Blueprint — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/institute/the-degree.html
+++ b/institute/the-degree.html
@@ -6,9 +6,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Degree — BA in Technology — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/anchors.html
+++ b/knowledge/anchors.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Strategic Anchors — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/catalog.html
+++ b/knowledge/catalog.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Catalog — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>
@@ -169,7 +169,7 @@
 </ul></dd><dt>artifact</dt><dd>A real cultural artifact shipped to a real audience — with the numbers.</dd><dt>description</dt><dd>Four years of taking culture in; now you put something back out and watch what the world does with it.
 </dd>
 </dl></li><li><dl>
-<dt>code</dt><dd>WKSP 101–402</dd><dt>dir</dt><dd>WKSP-101</dd><dt>name</dt><dd>The Workshop (Bottega)</dd><dt>units</dt><dd>2 per semester</dd><dt>thread</dt><dd>workshop</dd><dt>semester</dt><dd>1</dd><dt>degrees</dt><dd>both</dd><dt>status</dt><dd>day1</dd><dt>catalog_register</dt><dd>Project-based fabrication and design practicum, taken every semester (WKSP 101 through 402).</dd><dt>teaching_frame</dt><dd>A project team that ships — boards, amplifier and pedal electronics, motorcycle mechanics, camera rigs, drones and ocean sensors. External clients from Year 2; public exhibition every year.</dd><dt>outcomes</dt><dd><ul>
+<dt>code</dt><dd>WKSP 101–402</dd><dt>dir</dt><dd>WKSP-101</dd><dt>name</dt><dd>The Workshop (Bottega)</dd><dt>display</dt><dd>The Workshop</dd><dt>units</dt><dd>2 per semester</dd><dt>thread</dt><dd>workshop</dd><dt>semester</dt><dd>1</dd><dt>degrees</dt><dd>both</dd><dt>status</dt><dd>day1</dd><dt>catalog_register</dt><dd>Project-based fabrication and design practicum, taken every semester (WKSP 101 through 402).</dd><dt>teaching_frame</dt><dd>A project team that ships — boards, amplifier and pedal electronics, motorcycle mechanics, camera rigs, drones and ocean sensors. External clients from Year 2; public exhibition every year.</dd><dt>outcomes</dt><dd><ul>
 <li>craft</li><li>judgment</li>
 </ul></dd><dt>artifact</dt><dd>The shipped project, exhibited publicly, every single semester.</dd><dt>description</dt><dd>The bottega — the room where mastery is transmitted through making. Every semester, every student, on a project team that ships something real. The materials rotate through the region&#x27;s craft traditions; the standard never does.
 </dd>

--- a/knowledge/catalog.yaml
+++ b/knowledge/catalog.yaml
@@ -477,6 +477,7 @@ courses:
   - code: WKSP 101–402
     dir: WKSP-101
     name: The Workshop (Bottega)
+    display: The Workshop
     units: 2 per semester
     thread: workshop
     semester: 1

--- a/knowledge/community.html
+++ b/knowledge/community.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Community — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/degree.html
+++ b/knowledge/degree.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Degree Architecture — Bachelor of Arts in Technology — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/identity.html
+++ b/knowledge/identity.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Identity — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/index.html
+++ b/knowledge/index.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Knowledge — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/infrastructure.html
+++ b/knowledge/infrastructure.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Infrastructure — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/outcomes.html
+++ b/knowledge/outcomes.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Five Outcomes — Assessment Framework — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/philosophies.html
+++ b/knowledge/philosophies.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Core Philosophies — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/priorities.html
+++ b/knowledge/priorities.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Standing Order of Operations — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/programs.html
+++ b/knowledge/programs.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Programs — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/projects.html
+++ b/knowledge/projects.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Active Projects — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/knowledge/research.html
+++ b/knowledge/research.html
@@ -5,9 +5,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Research — SDIT</title>
-  <link rel="stylesheet" href="../dist/site/assets/site.css" />
-  <script src="../dist/site/assets/js/site-paths.js" defer></script>
-  <script src="../dist/site/assets/js/includes.js" defer></script>
+  <link rel="stylesheet" href="../assets/site.css" />
+  <script src="../assets/js/site-paths.js" defer></script>
+  <script src="../assets/js/includes.js" defer></script>
 </head>
 <body>
   <div data-include="/partials/header.html"></div>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -423,6 +423,10 @@ def main(argv: list[str] | None = None) -> int:
         OUT.mkdir(parents=True, exist_ok=True)
     write_assets()
 
+    # The schedule and course day lists pull from the course day files.
+    import sync_courses
+    sync_courses.main()
+
     knowledge_entries = render_knowledge(ROOT / "knowledge", OUT / "knowledge")
     institute_entries = render_markdown_tree(ROOT / "institute", OUT / "institute")
     courses_entries = render_markdown_tree(ROOT / "courses", OUT / "courses")

--- a/scripts/sync_courses.py
+++ b/scripts/sync_courses.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+sync_courses.py — the schedule and course day lists pull from the course files.
+
+Single source of truth: courses/<DIR>/day-NN.md (front-matter title + first
+body line as the dek) and knowledge/catalog.yaml (course names and semester).
+
+What it regenerates, in place, between markers:
+  1. courses/<DIR>/index.md   — "The Daily Path" day sections
+                                 (between <!-- sdit:days:begin/end -->)
+  2. curriculum/schedule.html — one Week section per published week
+                                 (between <!-- sdit:weeks:begin/end -->)
+
+Run directly, or let build_site.py call it before rendering. Never edits
+anything outside the markers.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "knowledge" / "catalog.yaml"
+SCHEDULE = ROOT / "curriculum" / "schedule.html"
+TOTAL_DAYS = 15
+
+# Monday-to-Friday rhythm for the shared Foundation semesters:
+# books, mathematics, science, computation, the Workshop.
+WEEKDAY_ORDER = {
+    1: ["HUM", "MATH", "PHYS", "CS", "WKSP"],   # semester 1
+    2: ["HUM", "MATH", "PHYS", "CS", "SIG", "WKSP"],
+}
+WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+
+def load_catalog():
+    import yaml
+    return yaml.safe_load(CATALOG.read_text(encoding="utf-8"))
+
+
+def parse_front_matter(text: str):
+    m = re.match(r"^---\n(.*?)\n---\n(.*)$", text, re.S)
+    if not m:
+        return {}, text
+    meta = {}
+    for line in m.group(1).splitlines():
+        if ":" in line:
+            k, v = line.split(":", 1)
+            meta[k.strip()] = v.strip().strip('"')
+    return meta, m.group(2)
+
+
+def day_info(course_dir: Path, n: int):
+    """Return (title, dek) for day n, or None if the file doesn't exist."""
+    f = course_dir / f"day-{n:02d}.md"
+    if not f.exists():
+        return None
+    meta, body = parse_front_matter(f.read_text(encoding="utf-8"))
+    title = meta.get("title", f"Day {n:02d}")
+    title = re.sub(r"^Day\s+\d+\s*[—–-]\s*", "", title).strip()
+    # Dek = first non-empty body line after the H1
+    dek = ""
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("---"):
+            continue
+        dek = line
+        break
+    return title, dek
+
+
+def sync_course_days() -> int:
+    """Regenerate 'The Daily Path' sections in every course index.md with markers."""
+    changed = 0
+    for index_md in sorted((ROOT / "courses").glob("*/index.md")):
+        src = index_md.read_text(encoding="utf-8")
+        if "<!-- sdit:days:begin -->" not in src:
+            continue
+        course_dir = index_md.parent
+        blocks = []
+        for n in range(1, TOTAL_DAYS + 1):
+            info = day_info(course_dir, n)
+            if info:
+                title, dek = info
+                block = f"### Day {n:02d} — {title}\n\n"
+                if dek:
+                    block += f"{dek}\n\n"
+                block += f"[Begin Day {n:02d} →](day-{n:02d}.html)\n"
+            else:
+                block = (
+                    f"### Day {n:02d} — *coming soon*\n\n"
+                    f"Being written — publishes with Week {n}. "
+                    f"All five courses advance together, week by week.\n"
+                )
+            blocks.append(block)
+        generated = "<!-- sdit:days:begin -->\n" + "\n".join(blocks) + "<!-- sdit:days:end -->"
+        new = re.sub(
+            r"<!-- sdit:days:begin -->.*?<!-- sdit:days:end -->",
+            generated.replace("\\", "\\\\"),
+            src,
+            flags=re.S,
+        )
+        if new != src:
+            index_md.write_text(new, encoding="utf-8")
+            changed += 1
+    return changed
+
+
+def semester_courses(catalog, semester: int):
+    """Catalog courses for a semester, in Mon→Fri rhythm order."""
+    rows = [
+        c for c in catalog.get("courses", [])
+        if c.get("semester") == semester and (ROOT / "courses" / c["dir"]).exists()
+    ]
+    order = WEEKDAY_ORDER.get(semester, [])
+
+    def key(c):
+        prefix = c["dir"].split("-")[0]
+        return order.index(prefix) if prefix in order else len(order)
+
+    return sorted(rows, key=key)
+
+
+def sync_schedule(catalog) -> int:
+    """Regenerate the Week sections of curriculum/schedule.html."""
+    src = SCHEDULE.read_text(encoding="utf-8")
+    if "<!-- sdit:weeks:begin -->" not in src:
+        return 0
+    courses = semester_courses(catalog, semester=1)
+
+    sections = []
+    for week in range(1, TOTAL_DAYS + 1):
+        rows = []
+        for i, c in enumerate(courses):
+            info = day_info(ROOT / "courses" / c["dir"], week)
+            if not info:
+                continue
+            title, _dek = info
+            day_name = WEEKDAY_NAMES[i] if i < len(WEEKDAY_NAMES) else ""
+            display = c.get("display") or c.get("name") or c["code"]
+            rows.append(
+                f'            <a href="/courses/{c["dir"]}/day-{week:02d}.html">'
+                f'<span class="l-name">{day_name} · {display}</span>'
+                f'<span class="l-meta">{title} →</span></a>'
+            )
+        if not rows:
+            continue
+        label_num = "Start Here" if week == 1 else f"Semester 1"
+        sections.append(
+            f'''    <section class="article" id="week-{week}">
+      <div class="frame article-grid">
+        <div class="article-label">Week {week}<span class="num">{label_num}</span></div>
+        <div class="article-body">
+          <nav class="ledger" aria-label="Week {week}" style="margin-top:0.5rem;">
+{chr(10).join(rows)}
+          </nav>
+          <p style="margin-top:1rem;font-size:0.88rem;color:var(--muted);">One schedule serves everyone for the first two years — the Foundation is identical for every student.</p>
+        </div>
+      </div>
+    </section>'''
+        )
+
+    generated = "<!-- sdit:weeks:begin -->\n" + "\n\n".join(sections) + "\n    <!-- sdit:weeks:end -->"
+    new = re.sub(
+        r"<!-- sdit:weeks:begin -->.*?<!-- sdit:weeks:end -->",
+        generated.replace("\\", "\\\\"),
+        src,
+        flags=re.S,
+    )
+    if new != src:
+        SCHEDULE.write_text(new, encoding="utf-8")
+        return 1
+    return 0
+
+
+def main() -> int:
+    catalog = load_catalog()
+    n = sync_course_days()
+    s = sync_schedule(catalog)
+    print(f"sync_courses: {n} course page(s) updated, schedule {'updated' if s else 'unchanged'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Semester 1 — one structure, five courses

HUM-101, MATH-110, PHYS-110, CS-110, WKSP-101 rebuilt on the same skeleton: **Overview** (SDIT teaching frame and philosophy) → **The Two Registers** (catalog + teaching frame) → **Learning Outcomes** (measurable, each mapped to the five institutional outcomes — the WSCUC Standard 2 evidence trail, on the page) → **The Made Thing** → **How You're Assessed** (unassisted exams, portfolio, annual gates) → **The Daily Path** with one section per day, 1–15.

## Single source of truth

New `scripts/sync_courses.py`: the course pages' day sections and the Schedule page's week ledgers are generated from the courses' own `day-NN.md` files (front-matter title + dek) and `catalog.yaml`, between markers. `build_site.py` runs it on every build — drop in `day-02.md` and the course page and Week 2 on the schedule appear on the next build.

## Dead-code strip

- `layout.js` 1181 → ~450 lines (BLA volume/chapter machinery removed) — and fixes lesson-page chrome under clean URLs (`npx serve` strips `.html`)
- `site.css` 3638 → ~1670 lines via selector-usage audit
- Course category badges now map to the real curriculum threads
- Generated pages' asset paths repaired via the proper build entrypoint

Validator passes; verified desktop + mobile in the local preview with a clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)